### PR TITLE
Use env vars first for credentials if no project is specified

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -42,14 +42,14 @@ class ConfigData {
   }
 
   getProjectById(projectId) {
-    return this.projects.find(project => project.id === projectId);
-  }
+    let project;
 
-  getProjectByIdWithEnvFallback(projectId) {
-    let project = this.getProjectById(projectId);
-
-    if (projectId === DEFAULT_PROJECT && !project) {
+    if (!projectId) {
       project = this.getProjectFromEnvironment();
+    }
+
+    if (!project) {
+      project = this.projects.find(project => project.id === (projectId || DEFAULT_PROJECT));
     }
 
     return project;

--- a/test/base-commands/twilio-client-command.test.js
+++ b/test/base-commands/twilio-client-command.test.js
@@ -44,20 +44,18 @@ describe('base-commands', () => {
       expect(ctx.testCmd.twilioClient.region).to.equal(undefined);
     });
 
-    setUpTest(['-l', 'debug'], () => 0).it('should fail for a non-existant default project', async ctx => {
+    setUpTest(['-l', 'debug'], () => 0).it('should fail for a non-existent default project', async ctx => {
       ctx.testCmd.exit = sinon.fake();
       await ctx.testCmd.run();
-      expect(ctx.stderr).to.contain('Using project: default');
       expect(ctx.stderr).to.contain('No project "default" configured');
       expect(ctx.stderr).to.contain('To add project, run: twilio project:add');
       expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');
       expect(ctx.testCmd.exit.calledWith(1)).to.be.true;
     });
 
-    setUpTest(['-p', 'alt', '-l', 'debug']).it('should fail for a non-existant project', async ctx => {
+    setUpTest(['-p', 'alt', '-l', 'debug']).it('should fail for a non-existent project', async ctx => {
       ctx.testCmd.exit = sinon.fake();
       await ctx.testCmd.run();
-      expect(ctx.stderr).to.contain('Using project: alt');
       expect(ctx.stderr).to.contain('No project "alt" configured');
       expect(ctx.stderr).to.contain('To add project, run: twilio project:add -p alt');
       expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -45,34 +45,11 @@ describe('services', () => {
         expect(project).to.equal(undefined);
       });
 
-      test.it('should return default project if it exists', () => {
+      test.it('should return default project if it exists, and no env vars', () => {
         const configData = new ConfigData();
         configData.addProject('default', constants.FAKE_ACCOUNT_SID);
 
-        const project = configData.getProjectByIdWithEnvFallback(DEFAULT_PROJECT);
-        expect(project.accountSid).to.equal(constants.FAKE_ACCOUNT_SID);
-        expect(project.apiKey).to.equal(undefined);
-        expect(project.apiSecret).to.equal(undefined);
-      });
-    });
-
-    describe('ConfigData.getProjectByIdWithEnvFallback', () => {
-      test.it('should return undefined if no projects or env vars', () => {
-        const configData = new ConfigData();
-        const project = configData.getProjectByIdWithEnvFallback(DEFAULT_PROJECT);
-        expect(project).to.equal(undefined);
-      });
-
-      test.it('should return default project if it exists, even with env vars', () => {
-        const configData = new ConfigData();
-        configData.addProject('default', constants.FAKE_ACCOUNT_SID);
-
-        process.env.TWILIO_ACCOUNT_SID = 'ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-        process.env.TWILIO_AUTH_TOKEN = 'api key should take precedence';
-        process.env.TWILIO_API_KEY = constants.FAKE_API_KEY;
-        process.env.TWILIO_API_SECRET = constants.FAKE_API_SECRET;
-
-        const project = configData.getProjectByIdWithEnvFallback(DEFAULT_PROJECT);
+        const project = configData.getProjectById();
         expect(project.accountSid).to.equal(constants.FAKE_ACCOUNT_SID);
         expect(project.apiKey).to.equal(undefined);
         expect(project.apiSecret).to.equal(undefined);
@@ -80,10 +57,12 @@ describe('services', () => {
 
       test.it('should return project populated from AccountSid/AuthToken env vars', () => {
         const configData = new ConfigData();
+        configData.addProject('default', constants.FAKE_ACCOUNT_SID);
+
         process.env.TWILIO_ACCOUNT_SID = constants.FAKE_ACCOUNT_SID;
         process.env.TWILIO_AUTH_TOKEN = FAKE_AUTH_TOKEN;
 
-        const project = configData.getProjectByIdWithEnvFallback(DEFAULT_PROJECT);
+        const project = configData.getProjectById();
         expect(project.accountSid).to.equal(constants.FAKE_ACCOUNT_SID);
         expect(project.apiKey).to.equal(constants.FAKE_ACCOUNT_SID);
         expect(project.apiSecret).to.equal(FAKE_AUTH_TOKEN);
@@ -91,26 +70,17 @@ describe('services', () => {
 
       test.it('should return project populated from AccountSid/ApiKey env vars', () => {
         const configData = new ConfigData();
+        configData.addProject('default', constants.FAKE_ACCOUNT_SID);
+
         process.env.TWILIO_ACCOUNT_SID = constants.FAKE_ACCOUNT_SID;
         process.env.TWILIO_AUTH_TOKEN = 'api key should take precedence';
         process.env.TWILIO_API_KEY = constants.FAKE_API_KEY;
         process.env.TWILIO_API_SECRET = constants.FAKE_API_SECRET;
 
-        const project = configData.getProjectByIdWithEnvFallback(DEFAULT_PROJECT);
+        const project = configData.getProjectById();
         expect(project.accountSid).to.equal(constants.FAKE_ACCOUNT_SID);
         expect(project.apiKey).to.equal(constants.FAKE_API_KEY);
         expect(project.apiSecret).to.equal(constants.FAKE_API_SECRET);
-      });
-
-      test.it('should ignore env vars if a non-default project is requested', () => {
-        const configData = new ConfigData();
-        process.env.TWILIO_ACCOUNT_SID = constants.FAKE_ACCOUNT_SID;
-        process.env.TWILIO_AUTH_TOKEN = 'api key should take precedence';
-        process.env.TWILIO_API_KEY = constants.FAKE_API_KEY;
-        process.env.TWILIO_API_SECRET = constants.FAKE_API_SECRET;
-
-        const project = configData.getProjectByIdWithEnvFallback('my-other-project');
-        expect(project).to.equal(undefined);
       });
     });
 


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
