### PR TITLE
Rename the base command flags to reduce chance of conflict with auto-generated commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,9 +137,9 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.13.tgz",
-      "integrity": "sha512-zkO8hRd5Sjl7a+GM9ZMNHLD8rneAPjFBFjkAwLPs/hEv72RnFeWSyW6eE1nDbKVzMyDUYmmWNQFp0lQuwhHCdA==",
+      "version": "1.5.14",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.14.tgz",
+      "integrity": "sha512-R9gat0yUjamDVd4trvFgjlx2XYuMz1nM0uEBFP6nR1zOQAwJ3E1zqYbsVlCMWiUDGjU1hYmudmK7IjAxDUoqDw==",
       "requires": {
         "@oclif/errors": "^1.2.2",
         "@oclif/parser": "^3.7.3",
@@ -224,21 +224,21 @@
       "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw=="
     },
     "@oclif/parser": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.3.tgz",
-      "integrity": "sha512-yfYpDzVn9ipo4HZtYLfMtd3j3ArpTQlRbQfy9pNnHFd4VedE2PNYQTRWYYMuu1FxEOoknlMZbzsewVvl41TvKg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.8.1.tgz",
+      "integrity": "sha512-0OavFuLj6FBTdZDD6DXdNqH4qdLFLQD/PKK1OvNZhUd4/5v/lp6Ftzilwmirf549naNHq0u15uk1YCBvym5tNQ==",
       "requires": {
         "@oclif/linewrap": "^1.0.0",
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "tslib": "^1.9.3"
       }
     },
     "@oclif/plugin-help": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.1.6.tgz",
-      "integrity": "sha512-M4kTERpPWNSM1Mga7K/zo9DWHLCVf2FRaIeXPoytmTPd+0kSvG3TR0Vc1bwx9/cxXoYyYGgEejwNlrfayr8FZw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-help/-/plugin-help-2.2.0.tgz",
+      "integrity": "sha512-56iIgE7NQfwy/ZrWrvrEfJGb5rrMUt409yoQGw4feiU101UudA1btN1pbUbcKBr7vY9KFeqZZcftXEGxOp7zBg==",
       "requires": {
-        "@oclif/command": "^1.5.8",
+        "@oclif/command": "^1.5.13",
         "chalk": "^2.4.1",
         "indent-string": "^3.2.0",
         "lodash.template": "^4.4.0",
@@ -248,61 +248,10 @@
         "wrap-ansi": "^4.0.0"
       },
       "dependencies": {
-        "@oclif/command": {
-          "version": "1.5.12",
-          "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.12.tgz",
-          "integrity": "sha512-D5/Kph9smL92X1z9WPmxFd9zDruFsCk4/LbfCaBmiO2Vyyt7Y9O6kI1YLsC3B0KC9wymSCTH14IK96rf9AFHfQ==",
-          "requires": {
-            "@oclif/errors": "^1.2.2",
-            "@oclif/parser": "^3.7.3",
-            "debug": "^4.1.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "@oclif/errors": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@oclif/errors/-/errors-1.2.2.tgz",
-          "integrity": "sha512-Eq8BFuJUQcbAPVofDxwdE0bL14inIiwt5EaKRVY9ZDIG11jwdXZqiQEECJx0VfnLyUZdYfRd/znDI/MytdJoKg==",
-          "requires": {
-            "clean-stack": "^1.3.0",
-            "fs-extra": "^7.0.0",
-            "indent-string": "^3.2.0",
-            "strip-ansi": "^5.0.0",
-            "wrap-ansi": "^4.0.0"
-          }
-        },
-        "@oclif/parser": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.3.tgz",
-          "integrity": "sha512-yfYpDzVn9ipo4HZtYLfMtd3j3ArpTQlRbQfy9pNnHFd4VedE2PNYQTRWYYMuu1FxEOoknlMZbzsewVvl41TvKg==",
-          "requires": {
-            "@oclif/linewrap": "^1.0.0",
-            "chalk": "^2.4.1",
-            "tslib": "^1.9.3"
-          }
-        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
         },
         "string-width": {
           "version": "3.1.0",
@@ -320,40 +269,6 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-4.0.0.tgz",
-          "integrity": "sha512-uMTsj9rDb0/7kk1PbcbCcwvHUxp60fGDB/NNXpVa0Q+ic/e7y5+BwTxKfQ33VYgDppSwi/FBzpetYzo8s6tfbg==",
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
           }
         }
       }
@@ -4158,9 +4073,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.31.0.tgz",
-      "integrity": "sha512-/E+WLKhBqMqg+LYaJI6/KAUYBO5boSn9ZFVhzyvOcWflLMcvGF9RdawxIcFjoXJFDygYASBVdmwAi7pe9JVW6w==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.31.1.tgz",
+      "integrity": "sha512-mrJn52HpWKcC0tLetrCpo26V7MfMJqGkpDqiqsWlhbQXqj/MORRsEEPahF2mBxpPqaZTTmmZvshQPUQB+kj/WA==",
       "requires": {
         "@types/express": "^4.16.1",
         "deprecate": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "author": "Twilio @twilio",
   "bugs": "https://github.com/twilio/twilio-cli/issues",
   "dependencies": {
-    "@oclif/command": "^1.5.13",
+    "@oclif/command": "^1.5.14",
     "@oclif/config": "^1.13.0",
-    "@oclif/plugin-help": "^2.1.6",
+    "@oclif/plugin-help": "^2.2.0",
     "chalk": "^2.4.2",
     "columnify": "^1.5.4",
     "fs-extra": "^7.0.1",
@@ -15,7 +15,7 @@
     "keytar": "^4.9.0",
     "shelljs": "^0.8.2",
     "tsv": "^0.2.0",
-    "twilio": "^3.31.0"
+    "twilio": "^3.31.1"
   },
   "devDependencies": {
     "@oclif/test": "^1.2.4",

--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -29,10 +29,10 @@ class BaseCommand extends Command {
     this.flags = flags;
     await this.loadConfig();
 
-    this.outputProcessor = OutputFormats[this.flags['output-format'] || DEFAULT_OUTPUT_FORMAT];
+    this.outputProcessor = OutputFormats[this.flags['cli-output-format'] || DEFAULT_OUTPUT_FORMAT];
 
     this.logger = new Logger({
-      level: LoggingLevel[flags['log-level'] || DEFAULT_LOG_LEVEL]
+      level: LoggingLevel[flags['cli-log-level'] || DEFAULT_LOG_LEVEL]
     });
 
     this.logger.debug('Config File: ' + this.configFile.filePath);
@@ -78,15 +78,17 @@ class BaseCommand extends Command {
 }
 
 BaseCommand.flags = {
-  'log-level': flags.enum({
+  'cli-log-level': flags.enum({
     char: 'l',
+    helpLabel: '-l',
     default: DEFAULT_LOG_LEVEL,
     options: Object.keys(LoggingLevel),
     description: 'Level of logging messages.'
   }),
 
-  'output-format': flags.enum({
+  'cli-output-format': flags.enum({
     char: 'o',
+    helpLabel: '-o',
     default: DEFAULT_OUTPUT_FORMAT,
     options: Object.keys(OutputFormats),
     description: 'Format of command output.'


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

---
Now you see something like this:
```
➜  twilio api:core:incoming-phone-numbers:list --help
Retrieve a list of incoming-phone-numbers belonging to the account used to make the request.

USAGE
  $ twilio api:core:incoming-phone-numbers:list

OPTIONS
  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
  -o=(columns|json|tsv)            [default: columns] Format of command output.
  -p, --project=project            Shorthand identifier for your Twilio project.
  --account-sid=account-sid        The SID of the Account that created the resources to read
  --beta                           Whether to include new phone numbers
  --friendly-name=friendly-name    A string that identifies the IncomingPhoneNumber resources to read
  --origin=origin                  Include phone numbers based on their origin. By default, phone numbers of all origin are included.
  --phone-number=phone-number      The phone numbers of the IncomingPhoneNumber resources to read
  --properties=properties          [default: sid,phoneNumber,friendlyName] The properties you would like to display (JSON output always shows all properties).
```

And this (note the `--log-level` flag that is part of the command spec): 
```
➜  twilio api:monitor:v1:alerts:list --help
list multiple Alerts resources

USAGE
  $ twilio api:monitor:v1:alerts:list

OPTIONS
  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
  -o=(columns|json|tsv)            [default: columns] Format of command output.
  -p, --project=project            Shorthand identifier for your Twilio project.
  --end-date=end-date              Only show Alerts on or before this date.
  --log-level=log-level            Only show alerts for this log-level.
  --properties=properties          [default: sid,errorCode,logLevel,alertText] The properties you would like to display (JSON output always shows all properties).
  --start-date=start-date          Only show Alerts on or after this date.
```
Made possible by https://github.com/oclif/plugin-help/issues/37