### PR TITLE
Condensed and standardized date output

### DIFF
--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -3,6 +3,7 @@ const { Config, ConfigData } = require('../services/config');
 const { Logger, LoggingLevel } = require('../services/messaging/logging');
 const { OutputFormats } = require('../services/output-formats');
 const { SecureStorage } = require('../services/secure-storage');
+
 let inquirer; // We'll lazy-load this only when it's needed.
 
 const DEFAULT_LOG_LEVEL = 'info';
@@ -49,12 +50,8 @@ class BaseCommand extends Command {
   }
 
   sanitizeProperty(propertiesVal) {
-    if (propertiesVal instanceof Date) {
-      var dateString = propertiesVal.toString();
-      var shortDate = dateString.slice(4, 33);
-      propertiesVal = shortDate;
-    }
-    return propertiesVal;
+    var shortDate = propertiesVal.slice(4, 33);
+    return shortDate;
   }
 
   output(fullData, properties, options) {
@@ -68,8 +65,12 @@ class BaseCommand extends Command {
         propNames.forEach(p => {
           if (fullItem[p] === undefined) {
             invalidPropertyNames.add(p);
+          } else if (fullItem[p] instanceof Date) {
+            const dateString = fullItem[p].toString();
+            var shortDate = this.sanitizeProperty(dateString);
+            limitedItem[p] = shortDate;
           } else {
-            limitedItem[p] = this.sanitizeProperty(fullItem[p]);
+            limitedItem[p] = fullItem[p];
           }
         });
         return limitedItem;

--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -48,6 +48,15 @@ class BaseCommand extends Command {
     this.userConfig = await this.configFile.load();
   }
 
+  sanitizeProperty(propertiesVal) {
+    if (propertiesVal instanceof Date) {
+      var dateString = propertiesVal.toString();
+      var shortDate = dateString.slice(4, 33);
+      propertiesVal = shortDate;
+    }
+    return propertiesVal;
+  }
+
   output(fullData, properties, options) {
     const dataArray = fullData.constructor === Array ? fullData : [fullData];
     const invalidPropertyNames = new Set();
@@ -60,12 +69,11 @@ class BaseCommand extends Command {
           if (fullItem[p] === undefined) {
             invalidPropertyNames.add(p);
           } else {
-            limitedItem[p] = fullItem[p];
+            limitedItem[p] = this.sanitizeProperty(fullItem[p]);
           }
         });
         return limitedItem;
       });
-
       if (invalidPropertyNames.size > 0) {
         const warn = this.logger.warn.bind(this.logger);
         invalidPropertyNames.forEach(p => {

--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -49,7 +49,7 @@ class BaseCommand extends Command {
     this.userConfig = await this.configFile.load();
   }
 
-  sanitizeProperty(propertiesVal) {
+  sanitizeDateString(propertiesVal) {
     var shortDate = propertiesVal.slice(4, 33);
     return shortDate;
   }
@@ -67,7 +67,7 @@ class BaseCommand extends Command {
             invalidPropertyNames.add(p);
           } else if (fullItem[p] instanceof Date) {
             const dateString = fullItem[p].toString();
-            var shortDate = this.sanitizeProperty(dateString);
+            var shortDate = this.sanitizeDateString(dateString);
             limitedItem[p] = shortDate;
           } else {
             limitedItem[p] = fullItem[p];

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -56,6 +56,9 @@ describe('base-commands', () => {
       baseCommandTest.it('check other timezone date is sliced correctly', ctx => {
         expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0700 (PDT)')).to.equal('May 24 2019 11:43:11 GMT-0700');
       });
+      baseCommandTest.it('check output if timezone in parenthesis is not included', ctx => {
+        expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0700')).to.equal('May 24 2019 11:43:11 GMT-0700');
+      });
       baseCommandTest.it('return empty string if the date is empty', ctx => {
         expect(ctx.testCmd.sanitizeDateString('')).to.equal('');
       });

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -49,6 +49,30 @@ describe('base-commands', () => {
         expect(ctx.stderr).to.contain(`[DEBUG] Config File: ${expectedConfigFile}`);
       });
 
+    describe('sanitizeProperty', () => {
+      baseCommandTest.it('check format for ISO dates that are inputted', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(new Date('2019-05-24T17:43:11.000Z'))).to.equal('May 24 2019 11:43:11 GMT-0600');
+      });
+      baseCommandTest.it('check format for ISO short date', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(new Date('2019-05-24'))).to.equal('May 23 2019 18:00:00 GMT-0600'); // defaults to time 00
+      });
+      baseCommandTest.it('check format for abbreviated text string', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(new Date('Fri May 24 2019 11:43:11 GMT-0600 (MDT)'))).to.equal('May 24 2019 11:43:11 GMT-0600');
+      });
+      baseCommandTest.it('check format for full text string', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(new Date('Fri May 24 2019 11:43:11 GMT-0600 (Mountain Daylight Time)'))).to.equal('May 24 2019 11:43:11 GMT-0600');
+      });
+      baseCommandTest.it('check format for short date', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(new Date('05/24/2019'))).to.equal('May 24 2019 00:00:00 GMT-0600'); // defaults to time 00
+      });
+      baseCommandTest.it('check to see other properties are returned', ctx => {
+        expect(ctx.testCmd.sanitizeProperty('properties')).to.equal('properties');
+      });
+      baseCommandTest.it('should return undefined', ctx => {
+        expect(ctx.testCmd.sanitizeProperty(undefined)).to.equal(undefined);
+      });
+    });
+
     describe('output', () => {
       const outputTest = baseCommandTest.stdout();
 

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -50,26 +50,11 @@ describe('base-commands', () => {
       });
 
     describe('sanitizeProperty', () => {
-      baseCommandTest.it('check format for ISO dates that are inputted', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(new Date('2019-05-24T17:43:11.000Z'))).to.equal('May 24 2019 11:43:11 GMT-0600');
+      baseCommandTest.it('check date is sliced correctly', ctx => {
+        expect(ctx.testCmd.sanitizeProperty('Fri May 24 2019 11:43:11 GMT-0600 (MDT)')).to.equal('May 24 2019 11:43:11 GMT-0600');
       });
-      baseCommandTest.it('check format for ISO short date', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(new Date('2019-05-24'))).to.equal('May 23 2019 18:00:00 GMT-0600'); // defaults to time 00
-      });
-      baseCommandTest.it('check format for abbreviated text string', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(new Date('Fri May 24 2019 11:43:11 GMT-0600 (MDT)'))).to.equal('May 24 2019 11:43:11 GMT-0600');
-      });
-      baseCommandTest.it('check format for full text string', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(new Date('Fri May 24 2019 11:43:11 GMT-0600 (Mountain Daylight Time)'))).to.equal('May 24 2019 11:43:11 GMT-0600');
-      });
-      baseCommandTest.it('check format for short date', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(new Date('05/24/2019'))).to.equal('May 24 2019 00:00:00 GMT-0600'); // defaults to time 00
-      });
-      baseCommandTest.it('check to see other properties are returned', ctx => {
-        expect(ctx.testCmd.sanitizeProperty('properties')).to.equal('properties');
-      });
-      baseCommandTest.it('should return undefined', ctx => {
-        expect(ctx.testCmd.sanitizeProperty(undefined)).to.equal(undefined);
+      baseCommandTest.it('check other timezone date is sliced correctly', ctx => {
+        expect(ctx.testCmd.sanitizeProperty('Fri May 24 2019 11:43:11 GMT-0700 (PDT)')).to.equal('May 24 2019 11:43:11 GMT-0700');
       });
     });
 

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -51,13 +51,13 @@ describe('base-commands', () => {
 
     describe('sanitizeProperty', () => {
       baseCommandTest.it('check date is sliced correctly', ctx => {
-        expect(ctx.testCmd.sanitizeProperty('Fri May 24 2019 11:43:11 GMT-0600 (MDT)')).to.equal('May 24 2019 11:43:11 GMT-0600');
+        expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0600 (MDT)')).to.equal('May 24 2019 11:43:11 GMT-0600');
       });
       baseCommandTest.it('check other timezone date is sliced correctly', ctx => {
-        expect(ctx.testCmd.sanitizeProperty('Fri May 24 2019 11:43:11 GMT-0700 (PDT)')).to.equal('May 24 2019 11:43:11 GMT-0700');
+        expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0700 (PDT)')).to.equal('May 24 2019 11:43:11 GMT-0700');
       });
       baseCommandTest.it('return empty string if the date is empty', ctx => {
-        expect(ctx.testCmd.sanitizeProperty('')).to.equal('');
+        expect(ctx.testCmd.sanitizeDateString('')).to.equal('');
       });
     });
 

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -56,6 +56,9 @@ describe('base-commands', () => {
       baseCommandTest.it('check other timezone date is sliced correctly', ctx => {
         expect(ctx.testCmd.sanitizeProperty('Fri May 24 2019 11:43:11 GMT-0700 (PDT)')).to.equal('May 24 2019 11:43:11 GMT-0700');
       });
+      baseCommandTest.it('return empty string if the date is empty', ctx => {
+        expect(ctx.testCmd.sanitizeProperty('')).to.equal('');
+      });
     });
 
     describe('output', () => {

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -49,7 +49,7 @@ describe('base-commands', () => {
         expect(ctx.stderr).to.contain(`[DEBUG] Config File: ${expectedConfigFile}`);
       });
 
-    describe('sanitizeProperty', () => {
+    describe('sanitizeDateString', () => {
       baseCommandTest.it('check date is sliced correctly', ctx => {
         expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0600 (MDT)')).to.equal('May 24 2019 11:43:11 GMT-0600');
       });


### PR DESCRIPTION
<!-- Describe your Pull Request -->
Previously the date output was too long. This PR removes the day of the week and the local time zone. It should also standardize the output to display month day year hours:minutes:seconds and off set from GMT time.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
