### PR TITLE
Remove project

### DIFF
--- a/src/services/config.js
+++ b/src/services/config.js
@@ -48,18 +48,26 @@ class ConfigData {
     if (!projectId) {
       project = this.getProjectFromEnvironment();
     }
-
-    if (this.projects.length > 0) {
-      if (!project) {
-        const selectedProjectId = projectId || this.activeProject;
-        if (selectedProjectId) {
-          project = this.projects.find(project => project.id === selectedProjectId);
-        } else {
-          project = this.projects[0];
-        }
+    if (!project) {
+      if (projectId) {
+        project = this.projects.find(project => project.id === projectId);
+      } else {
+        project = this.getActiveProject();
       }
     }
+    return project;
+  }
 
+  getActiveProject() {
+    let project;
+    if (this.projects.length > 0) {
+      if (this.activeProject) {
+        project = this.projects.find(project => project.id === this.activeProject);
+      }
+      if (!project) {
+        project = this.projects[0];
+      }
+    }
     return project;
   }
 
@@ -67,6 +75,9 @@ class ConfigData {
     this.projects = this.projects.filter(project => {
       return project.id !== projectToRemove.id;
     });
+    if (projectToRemove.id === this.activeProject) {
+      this.activeProject = null;
+    }
   }
 
   addProject(id, accountSid, region) {

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -115,7 +115,7 @@ describe('services', () => {
         expect(active.id).to.equal('secondProject');
         expect(active.accountSid).to.equal('new_account_SID');
       });
-      test.it('should return undefined if project does not exits and there are no prohjects configured', () => {
+      test.it('should return undefined if project does not exist and there are no projects configured', () => {
         const configData = new ConfigData();
         const active = configData.getActiveProject();
         expect(active).to.equal(undefined);
@@ -132,9 +132,10 @@ describe('services', () => {
           id: 'DOES_NOT_EXIST',
           accountSid: 'fake_SID'
         };
+        const originalLength = configData.projects.length;
         configData.removeProject(fakeProject);
 
-        expect(configData.projects.length).to.equal(configData.projects.length);
+        expect(configData.projects.length).to.equal(originalLength);
       });
       test.it('removes project', () => {
         const configData = new ConfigData();

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -93,6 +93,76 @@ describe('services', () => {
       });
     });
 
+    describe('ConfigData.getActiveProject', () => {
+      test.it('should return first project when no active project is set', () => {
+        const configData = new ConfigData();
+        configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
+        configData.addProject('secondProject', 'new_account_SID');
+        configData.addProject('thirdProject', 'newest_account_SID');
+        const active = configData.getActiveProject();
+
+        expect(active.id).to.equal('firstProject');
+        expect(active.accountSid).to.equal(constants.FAKE_ACCOUNT_SID);
+      });
+      test.it('should return active project when active project has been set', () => {
+        const configData = new ConfigData();
+        configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
+        configData.addProject('secondProject', 'new_account_SID');
+        configData.addProject('thirdProject', 'newest_account_SID');
+        configData.activeProject = 'secondProject';
+        const active = configData.getActiveProject();
+
+        expect(active.id).to.equal('secondProject');
+        expect(active.accountSid).to.equal('new_account_SID');
+      });
+      test.it('should return undefined if project does not exits and there are no prohjects configured', () => {
+        const configData = new ConfigData();
+        const active = configData.getActiveProject();
+        expect(active).to.equal(undefined);
+      });
+    });
+
+    describe('ConfigData.removeProject', () => {
+      test.it('remove a project that does not exist', () => {
+        // expect to return the same list
+        const configData = new ConfigData();
+        configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
+        configData.addProject('secondProject', 'new_account_SID');
+        configData.addProject('thirdProject', 'newest_account_SID');
+        const fakeProject = {
+          id: 'DOES_NOT_EXIST',
+          accountSid: 'fake_SID'
+        };
+        configData.removeProject(fakeProject);
+
+        expect(configData.projects.length).to.equal(configData.projects.length);
+      });
+      test.it('removes project', () => {
+        const configData = new ConfigData();
+        configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
+        configData.addProject('secondProject', 'new_account_SID');
+        configData.addProject('thirdProject', 'newest_account_SID');
+        const project = configData.getProjectById('secondProject');
+        configData.removeProject(project);
+
+        expect(configData.projects[1].id).to.equal('thirdProject');
+        expect(configData.projects[1].accountSid).to.equal('newest_account_SID');
+      });
+      test.it('removes active project', () => {
+        const configData = new ConfigData();
+        configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
+        configData.addProject('secondProject', 'new_account_SID');
+        configData.addProject('thirdProject', 'newest_account_SID');
+        const project = configData.getProjectById('firstProject');
+        configData.activeProject = 'firstProject';
+        configData.removeProject(project);
+
+        expect(configData.projects[1].id).to.equal('thirdProject');
+        expect(configData.projects[1].accountSid).to.equal('newest_account_SID');
+        expect(configData.activeProject).to.equal(null);
+      });
+    });
+
     describe('Config', () => {
       const tempConfigDir = tmp.dirSync({ unsafeCleanup: true });
 

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -124,7 +124,6 @@ describe('services', () => {
 
     describe('ConfigData.removeProject', () => {
       test.it('remove a project that does not exist', () => {
-        // expect to return the same list
         const configData = new ConfigData();
         configData.addProject('firstProject', constants.FAKE_ACCOUNT_SID);
         configData.addProject('secondProject', 'new_account_SID');


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Refactored `getProjectById` to use the new `getActiveProject` function that returns the active project. Added the `removeProject` function that will removed specific project.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
