### PR TITLE
Move naming and resource path utilities to core

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ module.exports = {
     JSUtils: require('./services/javascript-utilities'),
     logging: require('./services/messaging/logging'),
     templating: require('./services/messaging/templating'),
+    namingConventions: require('./services/naming-conventions'),
+    ResourcePathParser: require('./services/resource-path-parser'),
     outputFormats: require('./services/output-formats'),
     secureStorage: require('./services/secure-storage')
   },

--- a/src/services/naming-conventions.js
+++ b/src/services/naming-conventions.js
@@ -1,0 +1,28 @@
+const kebabCase = input => {
+  return input
+    .trim()
+    .replace(/[ _]/g, '-') // from snake_case (or spaces)
+    .replace(/([a-z\d])([A-Z])/g, '$1-$2') // from PascalCase or camelCase
+    .toLowerCase()
+    .replace(/-+/g, '-') // remove duplicate dashes
+    .replace(/^-|-$/g, ''); // remove leading and trailing dashes
+};
+
+const camelCase = input => {
+  return input
+    .trim()
+    .replace(/^[A-Z]/, g => g[0].toLowerCase()) // from PascalCase
+    .replace(/[A-Z]{2,}/g, g => g.toLowerCase()) // consecutive caps (e.g. "AWS")  TODO: What about AWSRoute53?
+    .replace(/[-_ ]([a-z])/g, g => g[1].toUpperCase()) // from kebab-case or snake_case (or spaces)
+    .replace(/ /g, ''); // remove any remaining spaces
+};
+
+const capitalize = input => {
+  return input.trim().replace(/^[a-z]/, g => g[0].toUpperCase()); // upper the first character
+};
+
+module.exports = {
+  kebabCase,
+  camelCase,
+  capitalize
+};

--- a/src/services/resource-path-parser.js
+++ b/src/services/resource-path-parser.js
@@ -1,0 +1,34 @@
+class ResourcePathParser {
+  constructor(pathString) {
+    this.pathParts = pathString.split('/');
+    this.isInstanceResource = pathString.endsWith('}.json') || pathString.endsWith('}');
+    this.version = this.pathParts[1];
+  }
+
+  removeFirstLeaf() {
+    this.pathParts.splice(1, 1); // e.g. '/v1/foo' becomes '/foo'
+  }
+
+  removeJsonExtension() {
+    this.pathParts[this.pathParts.length - 1] = this.pathParts[this.pathParts.length - 1].replace('.json', '');
+  }
+
+  normalizePath() {
+    this.removeFirstLeaf();
+    this.removeJsonExtension();
+  }
+
+  getFullPath() {
+    return this.pathParts.join('/');
+  }
+
+  forEachPathNode(callback) {
+    this.pathParts.filter(part => part).forEach(callback);
+  }
+
+  isPathVariable(pathNode) {
+    return pathNode.startsWith('{');
+  }
+}
+
+module.exports = ResourcePathParser;

--- a/test/services/naming-conventions.test.js
+++ b/test/services/naming-conventions.test.js
@@ -1,0 +1,118 @@
+const { kebabCase, camelCase, capitalize } = require('../../src/services/naming-conventions');
+
+const { expect, test } = require('@twilio/cli-test');
+
+describe('services', () => {
+  describe('namingConventions', () => {
+    describe('kebabCase', () => {
+      test.it('handles single word', () => {
+        expect(kebabCase('one')).to.equal('one');
+      });
+
+      test.it('trims leading and trailing spaces', () => {
+        expect(kebabCase('  one  ')).to.equal('one');
+      });
+
+      test.it('trims leading and trailing symbols', () => {
+        expect(kebabCase('__one__')).to.equal('one');
+      });
+
+      test.it('handles words with spaces', () => {
+        expect(kebabCase('one two')).to.equal('one-two');
+        expect(kebabCase('one two three')).to.equal('one-two-three');
+      });
+
+      test.it('handles two words with extra space', () => {
+        expect(kebabCase('one  two')).to.equal('one-two');
+        expect(kebabCase('one  two  three')).to.equal('one-two-three');
+      });
+
+      test.it('handles snake_case', () => {
+        expect(kebabCase('one_two')).to.equal('one-two');
+        expect(kebabCase('one_two_three')).to.equal('one-two-three');
+      });
+
+      test.it('handles camelCase', () => {
+        expect(kebabCase('oneTwo')).to.equal('one-two');
+        expect(kebabCase('oneTwoThree')).to.equal('one-two-three');
+      });
+
+      test.it('handles PascalCase', () => {
+        expect(kebabCase('OneTwo')).to.equal('one-two');
+        expect(kebabCase('OneTwoThree')).to.equal('one-two-three');
+      });
+
+      test.it('handles PascalCase with digits', () => {
+        expect(kebabCase('One1Two')).to.equal('one1-two');
+        expect(kebabCase('One1Two2Three')).to.equal('one1-two2-three');
+      });
+
+      test.it('handles kebab-case', () => {
+        expect(kebabCase('one-two')).to.equal('one-two');
+        expect(kebabCase('one-two-three')).to.equal('one-two-three');
+      });
+    });
+
+    describe('camelCase', () => {
+      test.it('handles single word', () => {
+        expect(camelCase('one')).to.equal('one');
+      });
+
+      test.it('handles all caps word', () => {
+        expect(camelCase('ONE')).to.equal('one');
+      });
+
+      test.it('trims leading and trailing spaces', () => {
+        expect(camelCase('  one  ')).to.equal('one');
+      });
+
+      test.it('trims leading and trailing symbols', () => {
+        expect(kebabCase('__one__')).to.equal('one');
+      });
+
+      test.it('handles words with spaces', () => {
+        expect(camelCase('one two')).to.equal('oneTwo');
+        expect(camelCase('one two three')).to.equal('oneTwoThree');
+      });
+
+      test.it('handles two words with extra space', () => {
+        expect(camelCase('one  two')).to.equal('oneTwo');
+        expect(camelCase('one  two  three')).to.equal('oneTwoThree');
+      });
+
+      test.it('handles snake_case', () => {
+        expect(camelCase('one_two')).to.equal('oneTwo');
+        expect(camelCase('one_two_three')).to.equal('oneTwoThree');
+      });
+
+      test.it('handles camelCase', () => {
+        expect(camelCase('oneTwo')).to.equal('oneTwo');
+        expect(camelCase('oneTwoThree')).to.equal('oneTwoThree');
+      });
+
+      test.it('handles PascalCase', () => {
+        expect(camelCase('OneTwo')).to.equal('oneTwo');
+        expect(camelCase('OneTwoThree')).to.equal('oneTwoThree');
+      });
+
+      test.it('handles kebab-case', () => {
+        expect(camelCase('one-two')).to.equal('oneTwo');
+        expect(camelCase('one-two-three')).to.equal('oneTwoThree');
+      });
+    });
+
+    describe('capitalize', () => {
+      test.it('handles single word', () => {
+        expect(capitalize('one')).to.equal('One');
+      });
+
+      test.it('handles multiple words', () => {
+        expect(capitalize('one two three')).to.equal('One two three');
+      });
+
+      test.it('trims leading and trailing spaces', () => {
+        expect(capitalize('  one  ')).to.equal('One');
+      });
+    });
+  });
+});

--- a/test/services/resource-path-parser.test.js
+++ b/test/services/resource-path-parser.test.js
@@ -1,0 +1,40 @@
+const ResourcePathParser = require('../../src/services/resource-path-parser');
+
+const { expect, test } = require('@twilio/cli-test');
+
+describe('services', () => {
+  describe('path-parser', () => {
+    describe('normalizePath', () => {
+      test.it('should remove the first part of a path', () => {
+        const parser = new ResourcePathParser('/v1/foo/bar');
+        parser.normalizePath();
+        expect(parser.getFullPath()).to.equal('/foo/bar');
+      });
+
+      test.it('should strip off .json', () => {
+        const parser = new ResourcePathParser('/v1/foo/bar/{blah}.json');
+        parser.normalizePath();
+        expect(parser.getFullPath()).to.equal('/foo/bar/{blah}');
+      });
+    });
+
+    describe('forEachPathNode', () => {
+      test.it('should enumerate each non-empty item in the path nodes', () => {
+        const parser = new ResourcePathParser('/foo/bar/{blah}');
+        const collectedNodes = [];
+        parser.forEachPathNode(pathNode => collectedNodes.push(pathNode)); // eslint-disable-line max-nested-callbacks
+        expect(collectedNodes).to.eql(['foo', 'bar', '{blah}']);
+      });
+    });
+
+    describe('isPathVariable', () => {
+      test.it('should identify if a path node string is a variable identifier', () => {
+        const parser = new ResourcePathParser('/foo/{AccountSid}/{Bar}/{Sid}');
+        expect(parser.isPathVariable('foo')).to.be.false;
+        expect(parser.isPathVariable('{AccountSid}')).to.be.true;
+        expect(parser.isPathVariable('{Bar}')).to.be.true;
+        expect(parser.isPathVariable('{Sid}')).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
These will be used by the new client that's going in core for now.

Straight cut-paste from the cli: https://github.com/twilio/twilio-cli/tree/bb9524e78f6082276ce102aa218cdc0ec0c07d40/src/services