### PR TITLE
Temporarily pin keytar

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "columnify": "^1.5.4",
     "fs-extra": "^7.0.1",
     "inquirer": "^6.3.1",
-    "keytar": "^4.9.0",
+    "keytar": "4.9.0",
     "shelljs": "^0.8.3",
     "tsv": "^0.2.0",
     "twilio": "^3.32.0"


### PR DESCRIPTION
Pending this fix: https://github.com/atom/node-keytar/issues/196

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
