### PR TITLE
Drop unsupported null-type object, patternProperties, and add RFC 2822 date time format

### DIFF
--- a/src/services/twilio-api/twilio_api.json
+++ b/src/services/twilio-api/twilio_api.json
@@ -7,9 +7,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -36,12 +38,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "type": {
@@ -73,9 +69,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "emergency_enabled": {
@@ -139,9 +137,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "emergency_address_sid": {
@@ -314,9 +314,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -479,9 +481,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "permissions": {
@@ -513,12 +517,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -951,9 +949,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "direction": {
@@ -963,6 +963,7 @@
             "type": "string"
           },
           "end_time": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "forwarded_from": {
@@ -1005,6 +1006,7 @@
             "type": "string"
           },
           "start_time": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "status": {
@@ -1021,12 +1023,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "to": {
@@ -1051,9 +1047,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "issues": {
@@ -1099,9 +1097,11 @@
             "type": "integer"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "end_date": {
@@ -1166,9 +1166,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "error_code": {
@@ -1178,6 +1180,7 @@
             "type": "string"
           },
           "message_date": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "message_text": {
@@ -1239,9 +1242,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "error_code": {
@@ -1251,6 +1256,7 @@
             "type": "string"
           },
           "message_date": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "message_text": {
@@ -1330,9 +1336,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "duration": {
@@ -1342,14 +1350,8 @@
             "type": "object"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
             "type": "number"
@@ -1376,6 +1378,7 @@
             "type": "string"
           },
           "start_time": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "status": {
@@ -1408,9 +1411,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -1434,12 +1439,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -1476,9 +1475,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "duration": {
@@ -1488,14 +1489,8 @@
             "type": "object"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
             "type": "number"
@@ -1522,6 +1517,7 @@
             "type": "string"
           },
           "start_time": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "status": {
@@ -1572,9 +1568,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "end_conference_on_exit": {
@@ -1720,9 +1718,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "emergency_address_sid": {
@@ -1904,9 +1904,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "description": {
@@ -1928,12 +1930,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "unique_name": {
@@ -2035,9 +2031,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2238,9 +2236,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2441,9 +2441,11 @@
             "type": "object"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2603,9 +2605,11 @@
       "api.v2010.account.key": {
         "properties": {
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2635,12 +2639,15 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_sent": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "direction": {
@@ -2653,14 +2660,8 @@
             "type": "string"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "error_message": {
             "type": "string"
@@ -2709,12 +2710,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "to": {
@@ -2738,9 +2733,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "parent_sid": {
@@ -2771,9 +2768,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "message_sid": {
@@ -2798,9 +2797,11 @@
       "api.v2010.account.new_key": {
         "properties": {
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2821,9 +2822,11 @@
       "api.v2010.account.new_signing_key": {
         "properties": {
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -2859,9 +2862,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "error_code": {
@@ -2871,6 +2876,7 @@
             "type": "string"
           },
           "message_date": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "message_text": {
@@ -2932,9 +2938,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "error_code": {
@@ -2944,6 +2952,7 @@
             "type": "string"
           },
           "message_date": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "message_text": {
@@ -3005,9 +3014,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3044,9 +3055,11 @@
             "type": "integer"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3077,6 +3090,7 @@
             "type": "string"
           },
           "date_enqueued": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "position": {
@@ -3125,9 +3139,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "duration": {
@@ -3137,14 +3153,8 @@
             "type": "object"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
             "type": "string"
@@ -3171,6 +3181,7 @@
             "type": "string"
           },
           "start_time": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "status": {
@@ -3185,12 +3196,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3221,12 +3226,15 @@
             "type": "string"
           },
           "date_completed": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "reference_sid": {
@@ -3255,12 +3263,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           }
         },
@@ -3296,9 +3298,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "label": {
@@ -3317,12 +3321,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           }
         },
@@ -3349,9 +3347,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "duration": {
@@ -3408,9 +3408,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3477,9 +3479,11 @@
       "api.v2010.account.signing_key": {
         "properties": {
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3507,9 +3511,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3522,12 +3528,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3552,9 +3552,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "sid": {
@@ -3588,9 +3590,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "domain_name": {
@@ -3609,12 +3613,6 @@
             "type": "boolean"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3704,9 +3702,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3730,9 +3730,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3760,9 +3762,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3786,9 +3790,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3801,12 +3807,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3825,9 +3825,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3840,12 +3842,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3864,9 +3860,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3879,12 +3877,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -3906,9 +3898,11 @@
             "type": "integer"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -3948,9 +3942,11 @@
             "type": "integer"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {
@@ -4014,12 +4010,15 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_sent": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "direction": {
@@ -4077,9 +4076,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "ice_servers": {
@@ -4112,9 +4113,11 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "duration": {
@@ -4446,12 +4449,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -4750,12 +4747,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -5054,12 +5045,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -5358,12 +5343,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -5662,12 +5641,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -5966,12 +5939,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -6270,12 +6237,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -6574,12 +6535,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -6878,12 +6833,6 @@
             "type": "string"
           },
           "subresource_uris": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "uri": {
@@ -6935,12 +6884,15 @@
             "type": "string"
           },
           "date_created": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_fired": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "date_updated": {
+            "format": "date-time-rfc-2822",
             "type": "string"
           },
           "friendly_name": {

--- a/src/services/twilio-api/twilio_authy.json
+++ b/src/services/twilio-api/twilio_authy.json
@@ -44,12 +44,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -85,12 +79,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {
@@ -160,12 +148,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {

--- a/src/services/twilio-api/twilio_autopilot.json
+++ b/src/services/twilio-api/twilio_autopilot.json
@@ -37,12 +37,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "log_queries": {
@@ -147,12 +141,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -239,14 +227,8 @@
             "type": "string"
           },
           "build_duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
             "format": "date-time",
@@ -257,14 +239,8 @@
             "type": "string"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
             "maxLength": 34,
@@ -408,12 +384,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {

--- a/src/services/twilio-api/twilio_chat.json
+++ b/src/services/twilio-api/twilio_chat.json
@@ -88,12 +88,6 @@
             "type": "object"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "notifications": {
@@ -165,12 +159,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "members_count": {
@@ -287,14 +275,8 @@
             "type": "string"
           },
           "last_consumed_message_index": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
             "format": "date-time",
@@ -473,12 +455,6 @@
             "type": "integer"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "role_sid": {
@@ -521,22 +497,10 @@
             "type": "string"
           },
           "last_consumed_message_index": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "member_sid": {
@@ -560,14 +524,8 @@
             "type": "string"
           },
           "unread_messages_count": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           }
         },
         "type": "object"
@@ -659,12 +617,6 @@
             "type": "object"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "media": {
@@ -753,12 +705,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "message_types": {
@@ -812,12 +758,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "members_count": {
@@ -984,14 +924,8 @@
             "type": "string"
           },
           "last_consumed_message_index": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "last_consumption_timestamp": {
             "format": "date-time",
@@ -1179,12 +1113,6 @@
             "type": "integer"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "role_sid": {
@@ -1294,22 +1222,10 @@
             "type": "string"
           },
           "last_consumed_message_index": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "member_sid": {
@@ -1340,14 +1256,8 @@
             "type": "string"
           },
           "unread_messages_count": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "url": {
             "format": "uri",
@@ -2668,14 +2578,8 @@
             "name": "LastConsumedMessageIndex",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
+              "nullable": true,
+              "type": "integer"
             }
           }
         ],
@@ -6242,14 +6146,8 @@
             "name": "LastConsumedMessageIndex",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
+              "nullable": true,
+              "type": "integer"
             }
           },
           {
@@ -6496,14 +6394,8 @@
             "name": "LastConsumedMessageIndex",
             "required": false,
             "schema": {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
+              "nullable": true,
+              "type": "integer"
             }
           },
           {

--- a/src/services/twilio-api/twilio_fax.json
+++ b/src/services/twilio-api/twilio_fax.json
@@ -28,25 +28,13 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "from": {
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "media_sid": {
@@ -59,14 +47,8 @@
             "type": "string"
           },
           "num_pages": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "price": {
             "type": "number"

--- a/src/services/twilio-api/twilio_insights.json
+++ b/src/services/twilio-api/twilio_insights.json
@@ -47,14 +47,8 @@
             "type": "object"
           },
           "connect_duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "direction": {
             "enum": [
@@ -75,14 +69,8 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
             "format": "date-time",

--- a/src/services/twilio-api/twilio_lookups.json
+++ b/src/services/twilio-api/twilio_lookups.json
@@ -106,12 +106,6 @@
             "name": "AddOnsData",
             "required": false,
             "schema": {
-              "patternProperties": {
-                "^.+$": {
-                  "format": "uri",
-                  "type": "string"
-                }
-              },
               "type": "object"
             }
           }

--- a/src/services/twilio-api/twilio_messaging.json
+++ b/src/services/twilio-api/twilio_messaging.json
@@ -69,12 +69,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "mms_converter": {
@@ -384,12 +378,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "messaging_service_sid": {

--- a/src/services/twilio-api/twilio_monitor.json
+++ b/src/services/twilio-api/twilio_monitor.json
@@ -191,12 +191,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "resource_sid": {

--- a/src/services/twilio-api/twilio_notify.json
+++ b/src/services/twilio-api/twilio_notify.json
@@ -100,12 +100,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "log_enabled": {
@@ -165,12 +159,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "notification_protocol_version": {
@@ -343,12 +331,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "segments": {
@@ -438,12 +420,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "notification_protocol_version": {

--- a/src/services/twilio-api/twilio_numbers.json
+++ b/src/services/twilio-api/twilio_numbers.json
@@ -27,12 +27,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -297,12 +291,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "purchase_intent_iso_country": {

--- a/src/services/twilio-api/twilio_preview.json
+++ b/src/services/twilio-api/twilio_preview.json
@@ -21,12 +21,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -142,12 +136,6 @@
       "preview.bulk_exports.export": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "resource_type": {
@@ -231,12 +219,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -765,12 +747,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -1279,12 +1255,6 @@
             "type": "object"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "start_time": {
@@ -1304,12 +1274,6 @@
       "preview.insights.call.report.aspects": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -1408,12 +1372,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "pricing_type": {
@@ -1488,12 +1446,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -1799,12 +1751,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "loa_date_signed": {
@@ -1972,12 +1918,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -2038,12 +1978,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -2142,12 +2076,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "reachability_webhooks_enabled": {
@@ -2193,12 +2121,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -2285,12 +2207,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -2424,12 +2340,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -2702,12 +2612,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "log_queries": {
@@ -2833,12 +2737,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -2925,14 +2823,8 @@
             "type": "string"
           },
           "build_duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "date_created": {
             "format": "date-time",
@@ -2943,14 +2835,8 @@
             "type": "string"
           },
           "error_code": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "sid": {
             "maxLength": 34,
@@ -3094,12 +2980,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -3423,12 +3303,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "rate_plan_sid": {

--- a/src/services/twilio-api/twilio_pricing.json
+++ b/src/services/twilio-api/twilio_pricing.json
@@ -226,6 +226,9 @@
                 "current_price": {
                   "type": "number"
                 },
+                "friendly_name": {
+                  "type": "string"
+                },
                 "prefixes": {
                   "items": "string",
                   "type": "array"
@@ -358,6 +361,9 @@
                 "destination_prefixes": {
                   "items": "string",
                   "type": "array"
+                },
+                "friendly_name": {
+                  "type": "string"
                 },
                 "origination_prefixes": {
                   "items": "string",

--- a/src/services/twilio-api/twilio_pricing.json
+++ b/src/services/twilio-api/twilio_pricing.json
@@ -4,12 +4,6 @@
       "pricing.v1.messaging": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -106,12 +100,6 @@
       "pricing.v1.phone_number": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -177,12 +165,6 @@
       "pricing.v1.voice": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -219,34 +201,13 @@
             "items": {
               "properties": {
                 "base_price": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "number"
                 },
                 "current_price": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "number"
                 },
                 "number_type": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -292,34 +253,13 @@
           "inbound_call_price": {
             "properties": {
               "base_price": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "number"
               },
               "current_price": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "number"
               },
               "number_type": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "string"
               }
             },
             "type": "object"
@@ -354,12 +294,6 @@
       "pricing.v2.voice": {
         "properties": {
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -396,34 +330,13 @@
             "items": {
               "properties": {
                 "base_price": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "number"
                 },
                 "current_price": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "number"
                 },
                 "number_type": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -476,34 +389,13 @@
           "inbound_call_price": {
             "properties": {
               "base_price": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "number"
               },
               "current_price": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "number"
               },
               "number_type": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "type": "string"
               }
             },
             "type": "object"

--- a/src/services/twilio-api/twilio_pricing.json
+++ b/src/services/twilio-api/twilio_pricing.json
@@ -69,18 +69,21 @@
                   "type": "string"
                 },
                 "prices": {
-                  "properties": {
-                    "base_price": {
-                      "type": "number"
+                  "items": {
+                    "properties": {
+                      "base_price": {
+                        "type": "number"
+                      },
+                      "current_price": {
+                        "type": "number"
+                      },
+                      "number_type": {
+                        "type": "string"
+                      }
                     },
-                    "current_price": {
-                      "type": "number"
-                    },
-                    "number_type": {
-                      "type": "string"
-                    }
+                    "type": "object"
                   },
-                  "type": "object"
+                  "type": "array"
                 }
               },
               "type": "object"
@@ -230,7 +233,9 @@
                   "type": "string"
                 },
                 "prefixes": {
-                  "items": "string",
+                  "items": {
+                    "type": "string"
+                  },
                   "type": "array"
                 }
               },
@@ -359,14 +364,18 @@
                   "type": "number"
                 },
                 "destination_prefixes": {
-                  "items": "string",
+                  "items": {
+                    "type": "string"
+                  },
                   "type": "array"
                 },
                 "friendly_name": {
                   "type": "string"
                 },
                 "origination_prefixes": {
-                  "items": "string",
+                  "items": {
+                    "type": "string"
+                  },
                   "type": "array"
                 }
               },

--- a/src/services/twilio-api/twilio_proxy.json
+++ b/src/services/twilio-api/twilio_proxy.json
@@ -44,12 +44,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "number_selection_behavior": {
@@ -179,12 +173,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "mode": {
@@ -399,12 +387,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "proxy_identifier": {

--- a/src/services/twilio-api/twilio_serverless.json
+++ b/src/services/twilio-api/twilio_serverless.json
@@ -24,12 +24,6 @@
             "type": "boolean"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -68,12 +62,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {
@@ -236,12 +224,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {
@@ -380,12 +362,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {

--- a/src/services/twilio-api/twilio_studio.json
+++ b/src/services/twilio-api/twilio_studio.json
@@ -21,12 +21,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -87,12 +81,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -177,12 +165,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {
@@ -278,12 +260,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -368,12 +344,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "name": {

--- a/src/services/twilio-api/twilio_sync.json
+++ b/src/services/twilio-api/twilio_sync.json
@@ -24,12 +24,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "reachability_debouncing_enabled": {
@@ -88,12 +82,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -184,12 +172,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -331,12 +313,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "revision": {
@@ -478,12 +454,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {

--- a/src/services/twilio-api/twilio_taskrouter.json
+++ b/src/services/twilio-api/twilio_taskrouter.json
@@ -37,12 +37,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "multi_task_enabled": {
@@ -230,12 +224,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "priority": {
@@ -310,12 +298,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "reservation_status": {
@@ -388,12 +370,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -447,12 +423,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "max_reserved_workers": {
@@ -734,12 +704,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {
@@ -870,12 +834,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "reservation_status": {
@@ -1069,12 +1027,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {

--- a/src/services/twilio-api/twilio_trunking.json
+++ b/src/services/twilio-api/twilio_trunking.json
@@ -57,12 +57,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "recording": {
@@ -249,12 +243,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "phone_number": {
@@ -428,12 +416,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "sid": {

--- a/src/services/twilio-api/twilio_verify.json
+++ b/src/services/twilio-api/twilio_verify.json
@@ -27,12 +27,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "lookup_enabled": {
@@ -118,12 +112,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "service_sid": {

--- a/src/services/twilio-api/twilio_video.json
+++ b/src/services/twilio-api/twilio_video.json
@@ -25,30 +25,18 @@
             "type": "integer"
           },
           "date_completed": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "format": "date-time",
-                "type": "string"
-              }
-            ]
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "date_created": {
             "format": "date-time",
             "type": "string"
           },
           "date_deleted": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "format": "date-time",
-                "type": "string"
-              }
-            ]
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "duration": {
             "type": "integer"
@@ -61,12 +49,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "resolution": {
@@ -144,15 +126,9 @@
             "type": "string"
           },
           "date_updated": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "format": "date-time",
-                "type": "string"
-              }
-            ]
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
           },
           "enabled": {
             "type": "boolean"
@@ -177,15 +153,9 @@
             "type": "string"
           },
           "status_callback": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "format": "uri",
-                "type": "string"
-              }
-            ]
+            "format": "uri",
+            "nullable": true,
+            "type": "string"
           },
           "status_callback_method": {
             "enum": [
@@ -286,25 +256,13 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "grouping_sids": {
             "type": "object"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "offset": {
@@ -418,14 +376,8 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "enable_turn": {
             "type": "boolean"
@@ -435,12 +387,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "max_participants": {
@@ -532,14 +478,8 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "end_time": {
             "format": "date-time",
@@ -549,12 +489,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "room_sid": {
@@ -751,25 +685,13 @@
             "type": "string"
           },
           "duration": {
-            "anyOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "integer"
-              }
-            ]
+            "nullable": true,
+            "type": "integer"
           },
           "grouping_sids": {
             "type": "object"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "offset": {

--- a/src/services/twilio-api/twilio_voice.json
+++ b/src/services/twilio-api/twilio_voice.json
@@ -26,12 +26,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "low_risk_numbers_enabled": {
@@ -87,12 +81,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "low_risk_numbers_enabled": {

--- a/src/services/twilio-api/twilio_wireless.json
+++ b/src/services/twilio-api/twilio_wireless.json
@@ -188,12 +188,6 @@
             "type": "string"
           },
           "links": {
-            "patternProperties": {
-              "^.+$": {
-                "format": "uri",
-                "type": "string"
-              }
-            },
             "type": "object"
           },
           "rate_plan_sid": {


### PR DESCRIPTION
`patternProperties` not currently support by OAS v3: https://github.com/OAI/OpenAPI-Specification/issues/687

Proper `null` handling docs: https://swagger.io/docs/specification/data-models/data-types/#null

Docs on string formatting: https://swagger.io/docs/specification/data-models/data-types/#format