### PR TITLE
Move the non-2XX error handling down to the CliRequestClient

### DIFF
--- a/src/services/twilio-api/twilio-client.js
+++ b/src/services/twilio-api/twilio-client.js
@@ -1,5 +1,4 @@
 const pkg = require('../../../package.json');
-const { TwilioCliError } = require('../error');
 const { doesObjectHaveProperty } = require('../javascript-utilities');
 const { logger } = require('../messaging/logging');
 const OpenApiClient = require('../open-api-client');
@@ -148,14 +147,7 @@ class TwilioApiClient {
       }
     }
 
-    const { statusCode, body } = await this.apiClient.request(opts);
-
-    if (statusCode < 200 || statusCode >= 300) {
-      const parsed = JSON.parse(body);
-      throw new TwilioCliError(`Error code ${parsed.code} from Twilio: ${parsed.message}. See ${parsed.more_info} for more info.`, parsed.code);
-    }
-
-    return { statusCode, body };
+    return this.apiClient.request(opts);
   }
 }
 


### PR DESCRIPTION
This change allows commands using the Node helper lib to catch a TwilioCliError
when a non-2XX response is received.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
