### PR TITLE
fix: next page of results requests

### DIFF
--- a/src/services/open-api-client.js
+++ b/src/services/open-api-client.js
@@ -37,10 +37,6 @@ class OpenApiClient {
     const isPost = (opts.method.toLowerCase() === 'post');
     const params = this.getParams(opts, operation);
 
-    if (!opts.uri) {
-      opts.uri = this.getUri(opts);
-    }
-
     if (!opts.host) {
       opts.host = path.server;
     }
@@ -55,7 +51,11 @@ class OpenApiClient {
       }
     }
 
-    opts.uri = opts.host + opts.uri;
+    if (!opts.uri) {
+      opts.uri = this.getUri(opts);
+      opts.uri = opts.host + opts.uri;
+    }
+
     opts.params = (isPost ? null : params);
     opts.data = (isPost ? params : null);
 

--- a/test/services/twilio-api/twilio-client.test.js
+++ b/test/services/twilio-api/twilio-client.test.js
@@ -23,7 +23,7 @@ describe('services', () => {
             calls: [{
               sid: callSid
             }],
-            next_page_uri: '/nextPageOfResults'
+            next_page_uri: 'https://api.twilio.com/nextPageOfResults'
           });
           api.get('/nextPageOfResults').reply(200, {
             calls: [{


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Reported this issue: https://github.com/twilio/twilio-cli/issues/74
It breaks when listing items that have more than one page, nextPageUrl contains the full path, so adding the host to it will create a bad URL 

```
https://messaging.twilio.comhttps://messaging.twilio.com/v1/Services?PageSize=50&Page=1&PageToken=XXXX
```


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
