### PR TITLE
String-ify objects in columnar and TSV output formats

### DIFF
--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -78,16 +78,25 @@ class BaseCommand extends Command {
     const propNames = properties.split(',').map(p => p.trim());
     const limitedData = dataArray.map(fullItem => {
       const limitedItem = {};
+
       propNames.forEach(p => {
-        if (fullItem[p] === undefined) {
+        let propValue = fullItem[p];
+
+        if (propValue === undefined) {
           invalidPropertyNames.add(p);
-        } else if (fullItem[p] instanceof Date) {
-          const dateString = fullItem[p].toString();
-          limitedItem[p] = this.sanitizeDateString(dateString);
-        } else {
-          limitedItem[p] = fullItem[p];
+          return;
         }
+
+        if (propValue instanceof Date) {
+          const dateString = propValue.toString();
+          propValue = this.sanitizeDateString(dateString);
+        } else if (typeof propValue === 'object') {
+          propValue = JSON.stringify(propValue);
+        }
+
+        limitedItem[p] = propValue;
       });
+
       return limitedItem;
     });
 

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -20,7 +20,7 @@ const childCommandTest = test.twilioCliEnv().do(async ctx => {
 
 describe('base-commands', () => {
   describe('base-command', () => {
-    baseCommandTest.stderr().it('should initialize properly', async ctx => {
+    baseCommandTest.stderr().it('should initialize properly', ctx => {
       expect(ctx.testCmd.outputProcessor).to.equal(OutputFormats.columns);
       expect(ctx.testCmd.logger).to.be.an.instanceOf(Logger);
       expect(ctx.testCmd.logger.config.level).to.equal(LoggingLevel.info);
@@ -28,7 +28,7 @@ describe('base-commands', () => {
       expect(ctx.stderr).to.equal('');
     });
 
-    childCommandTest.stderr().it('should initialize properly from children', async ctx => {
+    childCommandTest.stderr().it('should initialize properly from children', ctx => {
       expect(ctx.testCmd.outputProcessor).to.equal(OutputFormats.columns);
       expect(ctx.testCmd.logger).to.be.an.instanceOf(Logger);
       expect(ctx.testCmd.logger.config.level).to.equal(LoggingLevel.info);
@@ -43,7 +43,7 @@ describe('base-commands', () => {
         ctx.testCmd = new BaseCommand(['-l', 'debug'], ctx.fakeConfig);
         await ctx.testCmd.run();
       })
-      .it('should debug log the config file path', async ctx => {
+      .it('should debug log the config file path', ctx => {
         expect(ctx.testCmd.logger.config.level).to.equal(LoggingLevel.debug);
         const expectedConfigFile = path.join(ctx.fakeConfig.configDir, 'config.json');
         expect(ctx.stderr).to.contain(`[DEBUG] Config File: ${expectedConfigFile}`);
@@ -67,28 +67,37 @@ describe('base-commands', () => {
     describe('output', () => {
       const outputTest = baseCommandTest.stdout();
 
-      outputTest.it('should output a single object', async ctx => {
+      outputTest.it('should output a single object', ctx => {
         ctx.testCmd.output({ foo: 'foo', bar: 'bar' });
         expect(ctx.stdout).to.contain('Foo  Bar\nfoo  bar');
       });
 
-      outputTest.it('should output an array of objects', async ctx => {
+      outputTest.it('should output an array of objects', ctx => {
         ctx.testCmd.output([{ foo: 'foo', bar: 'bar' }, { foo: '2', bar: '2' }]);
         expect(ctx.stdout).to.contain('Foo  Bar\nfoo  bar\n2    2');
       });
 
-      outputTest.it('should output requested properties', async ctx => {
+      outputTest.it('should output requested properties', ctx => {
         ctx.testCmd.output([{ foo: 'foo', bar: 'bar', baz: 'baz' }, { foo: '2', bar: '2', baz: '2' }], 'foo, bar');
         expect(ctx.stdout).to.contain('Foo  Bar\nfoo  bar\n2    2');
       });
 
-      outputTest.stderr().it('should warn if invalid property name passed', async ctx => {
+      outputTest.stderr().it('should warn if invalid property name passed', ctx => {
         ctx.testCmd.output([{ foo: 'foo', bar: 'bar', baz: 'baz' }, { foo: '2', bar: '2', baz: '2' }], 'foo, barn');
         expect(ctx.stdout).to.contain('Foo\nfoo\n2');
         expect(ctx.stderr).to.contain('"barn" is not a valid property name.');
       });
 
-      outputTest.stderr().it('should output a message when the array is empty', async ctx => {
+      outputTest.it('should output requested object properties', ctx => {
+        ctx.testCmd.output([
+          { foo: 'foo', bar: { baz: 1, boz: 2 } },
+          { foo: '2', bar: { baz: 3, boz: 'four' } }
+        ], 'foo, bar');
+        expect(ctx.stdout).to.contain('foo  {"baz":1,"boz":2}');
+        expect(ctx.stdout).to.contain('2    {"baz":3,"boz":"four"}');
+      });
+
+      outputTest.stderr().it('should output a message when the array is empty', ctx => {
         ctx.testCmd.output([]);
         expect(ctx.stdout).to.be.empty;
         expect(ctx.stderr).to.contain('No results');
@@ -101,7 +110,7 @@ describe('base-commands', () => {
           await ctx.testCmd.run();
         })
         .stdout()
-        .it('should output an array of objects as JSON', async ctx => {
+        .it('should output an array of objects as JSON', ctx => {
           const testData = [{ foo: 'foo', bar: 'bar' }, { foo: '2', bar: '2' }];
           ctx.testCmd.output(testData);
           const outputObject = JSON.parse(ctx.stdout);
@@ -115,7 +124,7 @@ describe('base-commands', () => {
           await ctx.testCmd.run();
         })
         .stdout()
-        .it('should output an array of objects as TSV', async ctx => {
+        .it('should output an array of objects as TSV', ctx => {
           const testData = [{ FOO: 'foo', BAR: 'bar' }, { FOO: '2', BAR: '2' }];
           ctx.testCmd.output(testData);
           expect(ctx.stdout).to.contain('FOO\tBAR\nfoo\tbar\n2\t2');


### PR DESCRIPTION
Before:
```
> twilio api:core:incoming-phone-numbers:list --properties "dateCreated,capabilities"
Date Created                   Capabilities   
Jan 09 2019 18:22:24 GMT-0600  [object Object]
May 20 2019 09:34:18 GMT-0500  [object Object]
May 20 2019 09:31:47 GMT-0500  [object Object]
```
After:
```
> twilio api:core:incoming-phone-numbers:list --properties "dateCreated,capabilities"
Date Created                   Capabilities                         
Jan 09 2019 18:22:24 GMT-0600  {"mms":true,"sms":true,"voice":true} 
May 20 2019 09:34:18 GMT-0500  {"mms":false,"sms":true,"voice":true}
May 20 2019 09:31:47 GMT-0500  {"mms":true,"sms":true,"voice":true} 
```