### PR TITLE
Drop specific properties from 'phone_number_capabilities' types

### DIFF
--- a/src/services/twilio-api/twilio_api.json
+++ b/src/services/twilio-api/twilio_api.json
@@ -535,17 +535,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -590,17 +579,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -645,17 +623,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -700,17 +667,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -755,17 +711,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -810,17 +755,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -865,17 +799,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "friendly_name": {
@@ -1704,17 +1627,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {
@@ -2017,17 +1929,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {
@@ -2222,17 +2123,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {
@@ -2427,17 +2317,6 @@
             "type": "boolean"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {

--- a/src/services/twilio-api/twilio_preview.json
+++ b/src/services/twilio-api/twilio_preview.json
@@ -501,17 +501,6 @@
             "type": "integer"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "cc_emails": {
@@ -624,17 +613,6 @@
             "type": "integer"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "cc_emails": {

--- a/src/services/twilio-api/twilio_proxy.json
+++ b/src/services/twilio-api/twilio_proxy.json
@@ -82,17 +82,6 @@
             "type": "string"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {
@@ -580,17 +569,6 @@
             "type": "string"
           },
           "capabilities": {
-            "properties": {
-              "mms": {
-                "type": "boolean"
-              },
-              "sms": {
-                "type": "boolean"
-              },
-              "voice": {
-                "type": "boolean"
-              }
-            },
             "type": "object"
           },
           "date_created": {


### PR DESCRIPTION
The case of these properties is inconsistent across APIs so we'll no longer
explicitly list them.

Before:
```
> twilio api:core:available-phone-numbers:mobile:list --country-code GB --properties="phoneNumber,capabilities"
Phone Number   Capabilities  
+447723568014  {"voice":true}
+447723474023  {"voice":true}
```

After:
```
> twilio api:core:available-phone-numbers:mobile:list --country-code GB --properties="phoneNumber,capabilities"
Phone Number   Capabilities                                    
+447723582205  {"voice":true,"sms":true,"mms":false,"fax":true}
+447723486799  {"voice":true,"sms":true,"mms":false,"fax":true}
```