### PR TITLE
fix: update the wording for the env vars help message

### DIFF
--- a/src/base-commands/twilio-client-command.js
+++ b/src/base-commands/twilio-client-command.js
@@ -1,4 +1,3 @@
-const chalk = require('chalk');
 const { flags } = require('@oclif/command');
 const BaseCommand = require('./base-command');
 const CliRequestClient = require('../services/cli-http-client');
@@ -25,14 +24,14 @@ class TwilioClientCommand extends BaseCommand {
     this.currentProfile = this.userConfig.getProfileById(this.flags.profile);
 
     const reportUnconfigured = (verb, message = '') => {
-      const profileParam = this.flags.profile ? ' -p ' + this.flags.profile : '';
+      const profileParam = this.flags.profile ? ` --profile "${this.flags.profile}"` : '';
       throw new TwilioCliError(
-        `To ${verb} the profile, run: ` + chalk.whiteBright('twilio profiles:create' + profileParam) + message
+        `To ${verb} the profile, run:\n\n  twilio profiles:create${profileParam}${message}`
       );
     };
 
     if (!this.currentProfile) {
-      this.logger.error('No profile configured.');
+      this.logger.error(`Could not find profile "${this.flags.profile}".`);
       reportUnconfigured('create', '\n\n' + HELP_ENVIRONMENT_VARIABLES);
     }
 

--- a/src/services/messaging/help-messages.js
+++ b/src/services/messaging/help-messages.js
@@ -1,15 +1,17 @@
 const { CLI_NAME } = require('../config');
 
-exports.HELP_ENVIRONMENT_VARIABLES = `You can also use credentials stored in environment variables:
+exports.HELP_ENVIRONMENT_VARIABLES = `Alternatively, ${CLI_NAME} can use credentials stored in environment variables:
 
-#  OPTION 1 (recommended)
+# OPTION 1 (recommended)
 TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
 TWILIO_API_KEY = an API Key created at twil.io/get-api-key
 TWILIO_API_SECRET = the secret for the API Key
 
 # OPTION 2
 TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
-TWILIO_AUTH_TOKEN = your Auth Token from twil.io/console`;
+TWILIO_AUTH_TOKEN = your Auth Token from twil.io/console
+
+Once these environment variables are set, a ${CLI_NAME} profile is not required to move forward with installation.`;
 
 exports.UNEXPECTED_ERROR = `${CLI_NAME} encountered an unexpected error. \
 To report this issue, execute the command with the "-l debug" flag, then copy the output to a new issue here: \

--- a/test/base-commands/twilio-client-command.test.js
+++ b/test/base-commands/twilio-client-command.test.js
@@ -81,16 +81,18 @@ describe('base-commands', () => {
     setUpTest(['-l', 'debug'], { setUpUserConfig: () => 0 })
       .exit(1)
       .it('should fail for a non-existent active profile', ctx => {
-        expect(ctx.stderr).to.contain('No profile configured');
-        expect(ctx.stderr).to.contain('To create the profile, run: twilio profiles:create');
+        expect(ctx.stderr).to.contain('Could not find profile');
+        expect(ctx.stderr).to.contain('To create the profile, run:');
+        expect(ctx.stderr).to.contain('twilio profiles:create');
         expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');
       });
 
     setUpTest(['-p', 'alt', '-l', 'debug'])
       .exit(1)
       .it('should fail for a non-existent profile', ctx => {
-        expect(ctx.stderr).to.contain('No profile configured');
-        expect(ctx.stderr).to.contain('To create the profile, run: twilio profiles:create -p alt');
+        expect(ctx.stderr).to.contain('Could not find profile');
+        expect(ctx.stderr).to.contain('To create the profile, run:');
+        expect(ctx.stderr).to.contain('twilio profiles:create --profile "alt"');
         expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');
       });
 
@@ -105,9 +107,8 @@ describe('base-commands', () => {
       .exit(1)
       .it('should handle a secure storage error', ctx => {
         expect(ctx.stderr).to.contain('Could not get credentials for profile "twilio-cli-unit-testing"');
-        expect(ctx.stderr).to.contain(
-          'To reconfigure the profile, run: twilio profiles:create -p twilio-cli-unit-testing'
-        );
+        expect(ctx.stderr).to.contain('To reconfigure the profile, run:');
+        expect(ctx.stderr).to.contain('twilio profiles:create --profile "twilio-cli-unit-testing"');
       });
 
     setUpTest([], { commandClass: ThrowingClientCommand })


### PR DESCRIPTION
Output:

```
➜  twilio api:core:incoming-phone-numbers:list --profile="ugh ugh"
 » Could not find profile "ugh ugh".
 » To create the profile, run:

  twilio profiles:create --profile "ugh ugh"

Alternatively, twilio-cli can use credentials stored in environment variables:

# OPTION 1 (recommended)
TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
TWILIO_API_KEY = an API Key created at twil.io/get-api-key
TWILIO_API_SECRET = the secret for the API Key

# OPTION 2
TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
TWILIO_AUTH_TOKEN = your Auth Token from twil.io/console

Once these environment variables are set, a twilio-cli profile is not required to move forward with installation.
```

And:

```
➜  twilio login
 » Secure credential storage failed to load.

Alternatively, twilio-cli can use credentials stored in environment variables:

# OPTION 1 (recommended)
TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
TWILIO_API_KEY = an API Key created at twil.io/get-api-key
TWILIO_API_SECRET = the secret for the API Key

# OPTION 2
TWILIO_ACCOUNT_SID = your Account SID from twil.io/console
TWILIO_AUTH_TOKEN = your Auth Token from twil.io/console

Once these environment variables are set, a twilio-cli profile is not required to move forward with installation.
```