### PR TITLE
fix: only camelCase object keys when a schema is specified for the value

### DIFF
--- a/src/services/api-schema/twilio-converter.js
+++ b/src/services/api-schema/twilio-converter.js
@@ -18,7 +18,11 @@ class TwilioSchemaConverter extends JsonSchemaConverter {
       propValue = this.convertSchema(propSchema, propValue);
     }
 
-    return { propName: camelCase(propName), propValue };
+    if (propSchema) {
+      propName = camelCase(propName);
+    }
+
+    return { propName, propValue };
   }
 
   convertString(schema, value) {

--- a/test/services/api-schema.test.js
+++ b/test/services/api-schema.test.js
@@ -37,7 +37,7 @@ describe('services', () => {
           dateCreated: new Date('September 15, 2008 15:53 GMT+0500'),
           dateUpdated: new Date('September 15, 2008 15:53 GMT+0500'),
           messageType: ['not', 'a', 'message'],
-          freeFormObj: { firstKey: 'first_value', secondKey: 'second_value' },
+          freeFormObj: { first_key: 'first_value', second_key: 'second_value' },
           someUri: '/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.json'
         };
 


### PR DESCRIPTION
Studio flow definition keys were being converted to camelCase which was breaking updates that use the same definition.