### PR TITLE
feat: look through plugin pjson for an issue URL

### DIFF
--- a/src/services/messaging/help-messages.js
+++ b/src/services/messaging/help-messages.js
@@ -13,10 +13,6 @@ TWILIO_AUTH_TOKEN = your Auth Token from twil.io/console
 
 Once these environment variables are set, a ${CLI_NAME} profile is not required to move forward with installation.`;
 
-exports.UNEXPECTED_ERROR = `${CLI_NAME} encountered an unexpected error. \
-To report this issue, execute the command with the "-l debug" flag, then copy the output to a new issue here: \
-https://github.com/twilio/twilio-cli/issues`;
-
 exports.NETWORK_ERROR = `${CLI_NAME} encountered a network connectivity error. \
 Please check your network connection and try your command again. \
 Check on Twilio service status at https://status.twilio.com/`;

--- a/src/services/messaging/templates.js
+++ b/src/services/messaging/templates.js
@@ -1,7 +1,7 @@
 const { templatize } = require('./templating');
 
-const configSaved = templatize`twilio-cli configuration saved to "${'path'}"`;
+exports.configSaved = templatize`twilio-cli configuration saved to "${'path'}"`;
 
-module.exports = {
-  configSaved
-};
+exports.unexpectedError = templatize`twilio-cli encountered an unexpected error. \
+To report this issue, execute the command with the "-l debug" flag, then copy the output to a new issue here: \
+"${'url'}"`;

--- a/src/services/require-install.js
+++ b/src/services/require-install.js
@@ -8,7 +8,7 @@ const { logger } = require('./messaging/logging');
  * Retrieves the plugin for a given command.
  */
 const getCommandPlugin = command => {
-  for (let plugin of command.config.plugins) {
+  for (let plugin of command.config.plugins || []) {
     for (let pluginCommand of plugin.commands) {
       if (pluginCommand.id === command.id || pluginCommand.aliases.includes(command.id)) {
         // Check the plugin options/config name first. This will contain the

--- a/test/base-commands/base-command.test.js
+++ b/test/base-commands/base-command.test.js
@@ -67,6 +67,32 @@ describe('base-commands', () => {
         await expect(ctx.testCmd.catch(new TwilioCliError('hey-o!'))).to.be.rejectedWith(TwilioCliError);
       });
 
+    describe('getIssueUrl', () => {
+      baseCommandTest.it('follows the proper precedence order', ctx => {
+        const pjson = {
+          bugs: 'could be',
+          homepage: 'maybe',
+          repository: 'nope'
+        };
+
+        expect(ctx.testCmd.getIssueUrl({ pjson })).to.equal('could be');
+
+        delete pjson.bugs;
+        expect(ctx.testCmd.getIssueUrl({ pjson })).to.equal('maybe');
+
+        delete pjson.homepage;
+        expect(ctx.testCmd.getIssueUrl({ pjson })).to.equal('nope');
+      });
+
+      baseCommandTest.it('handles url properties', ctx => {
+        expect(ctx.testCmd.getIssueUrl({ pjson: { bugs: { email: 'me', url: 'you' } } })).to.equal('you');
+      });
+
+      baseCommandTest.it('use the main repo when no url is found', ctx => {
+        expect(ctx.testCmd.getIssueUrl({ pjson: { anything: 'nothing' } })).to.equal('https://github.com/twilio/twilio-cli/issues');
+      });
+    });
+
     describe('sanitizeDateString', () => {
       baseCommandTest.it('check date is sliced correctly', ctx => {
         expect(ctx.testCmd.sanitizeDateString('Fri May 24 2019 11:43:11 GMT-0600 (MDT)')).to.equal('May 24 2019 11:43:11 GMT-0600');


### PR DESCRIPTION
Rather than have the twilio-cli GitHub issues link used for all uncaught exceptions, use that of the plugin for plugin commands. This change will attempt to find the plugin bugs/homepage/repo URL when a plugin command extending our `BaseCommand` throws an uncaught exception. If found, it will be used as part of the error message. Otherwise, it will fallback to use the standard twilio-cli URL.