### PR TITLE
fix: delay module-loading error logs until all locations have been exhausted

### DIFF
--- a/test/services/require-install.test.js
+++ b/test/services/require-install.test.js
@@ -111,9 +111,8 @@ describe('services', () => {
       test.stderr().it('will attempt to install packages', async ctx => {
         const command = { id: 'top-command', config };
         await expect(requireInstall('chai-dai', command)).to.be.rejected;
-        expect(ctx.stderr).to.contain('Error loading chai-dai');
         expect(ctx.stderr).to.contain('Installing chai-dai');
-        expect(ctx.stderr).to.contain('Error installing chai-dai');
+        expect(ctx.stderr).to.contain('Error loading/installing chai-dai');
       });
     });
   });


### PR DESCRIPTION
If we're able to successfully load/install a runtime dependency, this change prevents any errors from being logged since we were successful in the end. This was confusing customers when they see things like keytar errors during the install process when everything's actually fine.