### PR TITLE
fix: don't display "undefined" when no profiles exists

### DIFF
--- a/src/base-commands/twilio-client-command.js
+++ b/src/base-commands/twilio-client-command.js
@@ -31,7 +31,8 @@ class TwilioClientCommand extends BaseCommand {
     };
 
     if (!this.currentProfile) {
-      this.logger.error(`Could not find profile "${this.flags.profile}".`);
+      const profileName = this.flags.profile ? ` "${this.flags.profile}"` : '';
+      this.logger.error(`Could not find profile${profileName}.`);
       reportUnconfigured('create', '\n\n' + HELP_ENVIRONMENT_VARIABLES);
     }
 

--- a/test/base-commands/twilio-client-command.test.js
+++ b/test/base-commands/twilio-client-command.test.js
@@ -85,7 +85,7 @@ describe('base-commands', () => {
     setUpTest(['-l', 'debug'], { setUpUserConfig: () => 0 })
       .exit(1)
       .it('should fail for a non-existent active profile', ctx => {
-        expect(ctx.stderr).to.contain('Could not find profile');
+        expect(ctx.stderr).to.contain('Could not find profile.');
         expect(ctx.stderr).to.contain('To create the profile, run:');
         expect(ctx.stderr).to.contain('twilio profiles:create');
         expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');
@@ -94,7 +94,7 @@ describe('base-commands', () => {
     setUpTest(['-p', 'alt', '-l', 'debug'])
       .exit(1)
       .it('should fail for a non-existent profile', ctx => {
-        expect(ctx.stderr).to.contain('Could not find profile');
+        expect(ctx.stderr).to.contain('Could not find profile "alt".');
         expect(ctx.stderr).to.contain('To create the profile, run:');
         expect(ctx.stderr).to.contain('twilio profiles:create --profile "alt"');
         expect(ctx.stderr).to.contain('TWILIO_ACCOUNT_SID');


### PR DESCRIPTION
If you've not created a profile yet and attempt to run a command that requires auth, you would see that the profile "undefined" could not be found. This change just updates the wording to indicate that a profile could not be found to use.

Relates to https://github.com/twilio/twilio-cli/issues/148