### PR TITLE
fix: encode URL path params

### DIFF
--- a/src/services/open-api-client.js
+++ b/src/services/open-api-client.js
@@ -83,6 +83,7 @@ class OpenApiClient {
 
       if (doesObjectHaveProperty(opts.pathParams, pathNode)) {
         value = opts.pathParams[pathNode];
+        value = encodeURIComponent(value);
       }
 
       logger.debug(`pathNode=${pathNode}, value=${value}`);

--- a/test/services/twilio-api/twilio-client.test.js
+++ b/test/services/twilio-api/twilio-client.test.js
@@ -232,6 +232,22 @@ describe('services', () => {
           expect(httpClient.lastRequest.data).to.eql(qs.stringify({ EmergencyEnabled: 'true' }));
         });
 
+      test
+        .nock('https://api.twilio.com', api => {
+          api.get(`/2010-04-01/Accounts/${accountSid}/Calls/hey%23there%3F.json`).reply(200, {
+            status: 'in-progress'
+          });
+        })
+        .it('encodes non-safe path param characters', async () => {
+          const response = await client.fetch({
+            domain: 'api',
+            path: '/2010-04-01/Accounts/{AccountSid}/Calls/{Sid}.json',
+            pathParams: { Sid: 'hey#there?' }
+          });
+
+          expect(response).to.eql({ status: 'in-progress' });
+        });
+
       /* eslint-disable max-nested-callbacks */
       describe('getLimit', () => {
         test.it('gets the limit', () => {


### PR DESCRIPTION
When referencing a resource by a unique name with non-safe characters, it needs to be URI-encoded or the request will fail.

Relates to https://github.com/twilio/twilio-node/issues/409