### PR TITLE
fix: don't get so fancy with the font color scheme

### DIFF
--- a/src/services/messaging/logging.js
+++ b/src/services/messaging/logging.js
@@ -9,10 +9,10 @@ const LoggingLevel = {
 };
 
 const LoggingLevelStyle = {
-  [LoggingLevel.debug]: msg => chalk.gray('[DEBUG] ' + msg),
-  [LoggingLevel.info]: msg => chalk.white(msg),
-  [LoggingLevel.warn]: msg => ' ' + chalk.yellowBright('»') + ' ' + chalk.white(msg),
-  [LoggingLevel.error]: msg => ' ' + chalk.red('»') + ' ' + chalk.whiteBright(msg)
+  [LoggingLevel.debug]: msg => chalk.dim('[DEBUG] ' + msg),
+  [LoggingLevel.info]: msg => msg,
+  [LoggingLevel.warn]: msg => chalk.italic(' » ' + msg),
+  [LoggingLevel.error]: msg => chalk.bold(' » ' + msg)
 };
 
 class Logger {


### PR DESCRIPTION
We should not use specific colors for coloring text because it could conflict with the terminal's background color.