### PR TITLE
fix: upgrade dependencies and drop tslib pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,37 +5,36 @@
   "author": "Twilio @twilio",
   "bugs": "https://github.com/twilio/twilio-cli/issues",
   "dependencies": {
-    "@oclif/command": "^1.5.19",
-    "@oclif/config": "^1.14.0",
-    "@oclif/errors": "^1.2.2",
-    "@oclif/plugin-help": "^2.2.3",
-    "@oclif/plugin-plugins": "^1.7.9",
+    "@oclif/command": "^1.7.0",
+    "@oclif/config": "^1.16.0",
+    "@oclif/errors": "^1.3.3",
+    "@oclif/plugin-help": "^3.1.0",
+    "@oclif/plugin-plugins": "^1.8.2",
     "axios": "^0.19.2",
-    "chalk": "^4.0.0",
+    "chalk": "^4.1.0",
     "columnify": "^1.5.4",
-    "fs-extra": "^9.0.0",
-    "inquirer": "^7.1.0",
-    "qs": "^6.9.3",
-    "semver": "^7.3.0",
-    "tslib": "~1.11.2",
+    "fs-extra": "^9.0.1",
+    "inquirer": "^7.3.0",
+    "qs": "^6.9.4",
+    "semver": "^7.3.2",
     "tsv": "^0.2.0",
-    "twilio": "^3.46.0"
+    "twilio": "^3.47.0"
   },
   "optionalDependencies": {
-    "keytar": "^5.4.0"
+    "keytar": "^6.0.1"
   },
   "devDependencies": {
-    "@oclif/test": "^1.2.5",
-    "@twilio/cli-test": "^2.0.2",
+    "@oclif/test": "^1.2.6",
+    "@twilio/cli-test": "^2.1.0",
     "chai": "^4.2.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.3.1",
     "eslint-config-oclif": "^3.1.0",
-    "eslint-plugin-mocha": "^6.3.0",
-    "mocha": "^7.1.1",
-    "nock": "^12.0.3",
-    "nyc": "^15.0.1",
+    "eslint-plugin-mocha": "^7.0.1",
+    "mocha": "^8.0.1",
+    "nock": "^13.0.2",
+    "nyc": "^15.1.0",
     "sinon": "^9.0.2",
-    "tmp": "0.1.0"
+    "tmp": "^0.2.1"
   },
   "engines": {
     "node": ">=10.12.0"
@@ -55,7 +54,7 @@
     "url": "https://github.com/twilio/twilio-cli-core.git"
   },
   "scripts": {
-    "posttest": "eslint --ignore-path .gitignore . && npm audit",
+    "posttest": "eslint --ignore-path .gitignore . && npm audit --audit-level=moderate",
     "test": "nyc --check-coverage --lines 90 --reporter=html --reporter=text mocha --forbid-only \"test/**/*.test.js\""
   }
 }


### PR DESCRIPTION
Pinning of tslib no longer required since '@oclif/plugin-plugins' has been fixed. Also, ignore low severity vulnerabilities until lodash issue is resolved: https://www.npmjs.com/advisories/1523