### PR TITLE
fix: allow API redirect responses

### DIFF
--- a/src/services/cli-http-client.js
+++ b/src/services/cli-http-client.js
@@ -93,7 +93,7 @@ class CliRequestClient {
       this.logger.debug(`response.statusCode: ${response.status}`);
       this.logger.debug(`response.headers: ${JSON.stringify(response.headers)}`);
 
-      if (response.status < 200 || response.status >= 300) {
+      if (response.status < 200 || response.status >= 400) {
         const parsed = response.data;
         throw new TwilioCliError(
           `Error code ${parsed.code} from Twilio: ${parsed.message}. See ${parsed.more_info} for more info.`,

--- a/test/services/twilio-api/twilio-client.test.js
+++ b/test/services/twilio-api/twilio-client.test.js
@@ -202,6 +202,20 @@ describe('services', () => {
 
       test
         .nock('https://api.twilio.com', (api) => {
+          api.get(`/2010-04-01/Accounts/${accountSid}/Messages.json`).reply(307, '{"redirect_to": "some_other_place"}');
+        })
+        .it('handles redirects', async () => {
+          const response = await apiClient.fetch({
+            domain: 'api',
+            path: '/2010-04-01/Accounts/{AccountSid}/Messages.json',
+          });
+
+          // eslint-disable-next-line camelcase
+          expect(response).to.eql({ redirect_to: 'some_other_place' });
+        });
+
+      test
+        .nock('https://api.twilio.com', (api) => {
           api
             .post(`/2010-04-01/Accounts/${accountSid}/Messages.json`)
             .reply(


### PR DESCRIPTION
Fetching a BulkExport for a single day returns a `307` with the AWS URL for the file. With this change, the URL will now be included in the CLI response.

https://www.twilio.com/docs/usage/bulkexport/day?code-sample=code-fetch-a-single-file-for-an-exported-day

Fixes https://github.com/twilio/twilio-cli/issues/207