### PR TITLE
fix: getParams when operation parameters is absent

### DIFF
--- a/src/services/open-api-client.js
+++ b/src/services/open-api-client.js
@@ -61,7 +61,7 @@ class OpenApiClient {
 
   getParams(opts, operation) {
     const params = {};
-    operation.parameters.forEach((parameter) => {
+    (operation.parameters || []).forEach((parameter) => {
       /*
        * Build the actual request params from the spec's query parameters. This
        * effectively drops all params that are not in the spec.

--- a/test/services/twilio-api/twilio-client.test.js
+++ b/test/services/twilio-api/twilio-client.test.js
@@ -317,6 +317,24 @@ describe('services', () => {
         });
       });
 
+      describe('absent operation parameters', () => {
+        test
+          .nock('https://conversations.twilio.com', (api) => {
+            api.get(`/v1/Configuration`).reply(200, {
+              // eslint-disable-next-line camelcase
+              account_sid: accountSid,
+            });
+          })
+          .it('can fetch', async () => {
+            const response = await apiClient.fetch({
+              domain: 'conversations',
+              path: '/v1/Configuration',
+            });
+
+            expect(response).to.eql({ accountSid });
+          });
+      });
+
       describe('regional and edge support', () => {
         const defaultRegionTest = test.nock('https://api.edge.us1.twilio.com', (api) => {
           api.post(`/2010-04-01/Accounts/${accountSid}/Messages.json`).reply(201, {


### PR DESCRIPTION
# Fixes https://github.com/twilio/twilio-cli/issues/229 #

This commit fixes a bug that happens when the operation's parameters are absent.
Accordingly to OpenAPI spec, operation parameters are not mandatory,
however, the existing code is expecting it.

Dependency of https://github.com/twilio/twilio-cli/pull/230

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli/blob/main/CONTRIBUTING.md), and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified
