### PR TITLE
feat: allow plugins to use the userConfig object to set arbitrary data 

### DIFF
--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -176,15 +176,15 @@ class BaseCommand extends Command {
       const pluginName = getCommandPlugin(this);
       this._pluginConfig = new PluginConfig(this.config.configDir, pluginName);
     }
-    return this._pluginConfig.getConfig();
+    return this._pluginConfig;
   }
 
-  set pluginConfig(config) {
-    if (!this._pluginConfig) {
-      const pluginName = getCommandPlugin(this);
-      this._pluginConfig = new PluginConfig(this.config.configDir, pluginName);
-    }
-    this._pluginConfig.setConfig(config);
+  async getPluginConfig() {
+    return this.pluginConfig.getConfig();
+  }
+
+  async setPluginConfig(config) {
+    return this.pluginConfig.setConfig(config);
   }
 }
 

--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -3,7 +3,7 @@ const { CLIError } = require('@oclif/errors');
 
 const pkg = require('../../package.json');
 const MessageTemplates = require('../services/messaging/templates');
-const { Config, ConfigData } = require('../services/config');
+const { Config, ConfigData, PluginConfig } = require('../services/config');
 const { TwilioCliError } = require('../services/error');
 const { logger, LoggingLevel } = require('../services/messaging/logging');
 const { OutputFormats } = require('../services/output-formats');
@@ -169,6 +169,22 @@ class BaseCommand extends Command {
 
   async install(name) {
     return requireInstall(name, this);
+  }
+
+  get pluginConfig() {
+    if (!this._pluginConfig) {
+      const pluginName = getCommandPlugin(this);
+      this._pluginConfig = new PluginConfig(this.config.configDir, pluginName);
+    }
+    return this._pluginConfig.getConfig();
+  }
+
+  set pluginConfig(config) {
+    if (!this._pluginConfig) {
+      const pluginName = getCommandPlugin(this);
+      this._pluginConfig = new PluginConfig(this.config.configDir, pluginName);
+    }
+    this._pluginConfig.setConfig(config);
   }
 }
 

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -197,21 +197,20 @@ class PluginConfig {
     this.filePath = path.join(configDir, 'plugins', pluginName, 'config.json');
   }
 
-  getConfig() {
+  async getConfig() {
     try {
-      const config = fs.readFileSync(this.filePath, { encoding: 'utf-8' });
-      return JSON.parse(config);
+      return await fs.readJSON(this.filePath, { encoding: 'utf-8' });
     } catch (error) {
       return {};
     }
   }
 
-  setConfig(config) {
+  async setConfig(config) {
     try {
-      fs.writeFileSync(this.filePath, JSON.stringify(config));
+      await fs.writeJSON(this.filePath, config);
     } catch (error) {
-      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
-      fs.writeFileSync(this.filePath, JSON.stringify(config));
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      await fs.writeJSON(this.filePath, config);
     }
   }
 }

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -147,6 +147,10 @@ class ConfigData {
     this.plugins[pluginName] = data;
   }
 
+  getPluginData(pluginName) {
+    return this.plugins[pluginName];
+  }
+
   removePluginData(pluginName) {
     delete this.plugins[pluginName];
   }

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -192,8 +192,33 @@ class Config {
   }
 }
 
+class PluginConfig {
+  constructor(configDir, pluginName) {
+    this.filePath = path.join(configDir, 'plugins', pluginName, 'config.json');
+  }
+
+  getConfig() {
+    try {
+      const config = fs.readFileSync(this.filePath, { encoding: 'utf-8' });
+      return JSON.parse(config);
+    } catch (error) {
+      return {};
+    }
+  }
+
+  setConfig(config) {
+    try {
+      fs.writeFileSync(this.filePath, JSON.stringify(config));
+    } catch (error) {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(config));
+    }
+  }
+}
+
 module.exports = {
   CLI_NAME,
   Config,
   ConfigData,
+  PluginConfig,
 };

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -147,10 +147,6 @@ class ConfigData {
     this.plugins[pluginName] = data;
   }
 
-  getPluginData(pluginName) {
-    return this.plugins[pluginName];
-  }
-
   removePluginData(pluginName) {
     delete this.plugins[pluginName];
   }

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -22,7 +22,6 @@ class ConfigData {
     this.prompts = {};
     this.profiles = [];
     this.activeProfile = null;
-    this.plugins = {};
   }
 
   getProfileFromEnvironment() {
@@ -143,14 +142,6 @@ class ConfigData {
     prompt.acked = true;
   }
 
-  setPluginData(pluginName, data) {
-    this.plugins[pluginName] = data;
-  }
-
-  removePluginData(pluginName) {
-    delete this.plugins[pluginName];
-  }
-
   loadFromObject(configObj) {
     this.edge = configObj.edge;
     this.email = configObj.email || {};
@@ -159,9 +150,6 @@ class ConfigData {
     configObj.profiles = configObj.projects || [];
     configObj.profiles.forEach((profile) => this.addProfile(profile.id, profile.accountSid, profile.region));
     this.setActiveProfile(configObj.activeProject);
-    Object.keys(configObj.plugins).forEach((pluginName) =>
-      this.setPluginData(pluginName, configObj.plugins[pluginName]),
-    );
   }
 
   sanitize(string) {
@@ -195,7 +183,6 @@ class Config {
       // Note the historical 'projects' naming.
       projects: configData.profiles,
       activeProject: configData.activeProfile,
-      plugins: configData.plugins,
     };
 
     fs.mkdirSync(this.configDir, { recursive: true });

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -22,6 +22,7 @@ class ConfigData {
     this.prompts = {};
     this.profiles = [];
     this.activeProfile = null;
+    this.plugins = {};
   }
 
   getProfileFromEnvironment() {
@@ -142,6 +143,14 @@ class ConfigData {
     prompt.acked = true;
   }
 
+  setPluginData(pluginName, data) {
+    this.plugins[pluginName] = data;
+  }
+
+  removePluginData(pluginName) {
+    delete this.plugins[pluginName];
+  }
+
   loadFromObject(configObj) {
     this.edge = configObj.edge;
     this.email = configObj.email || {};
@@ -150,6 +159,9 @@ class ConfigData {
     configObj.profiles = configObj.projects || [];
     configObj.profiles.forEach((profile) => this.addProfile(profile.id, profile.accountSid, profile.region));
     this.setActiveProfile(configObj.activeProject);
+    Object.keys(configObj.plugins).forEach((pluginName) =>
+      this.setPluginData(pluginName, configObj.plugins[pluginName]),
+    );
   }
 
   sanitize(string) {
@@ -183,6 +195,7 @@ class Config {
       // Note the historical 'projects' naming.
       projects: configData.profiles,
       activeProject: configData.activeProfile,
+      plugins: configData.plugins,
     };
 
     fs.mkdirSync(this.configDir, { recursive: true });

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -203,37 +203,6 @@ describe('services', () => {
       });
     });
 
-    describe('ConfigData.setPluginData', () => {
-      test.it('should add data for a new plugin', () => {
-        const configData = new ConfigData();
-        expect(configData.plugins['fancy-plugin']).to.be.undefined;
-        const testData = { arbitrary: 'data' };
-        configData.setPluginData('fancy-plugin', testData);
-
-        expect(configData.plugins['fancy-plugin']).to.deep.equal(testData);
-      });
-
-      test.it('should update data for an existing plugin', () => {
-        const configData = new ConfigData();
-        const testData = { arbitrary: 'data' };
-        const newData = { new: 'information' };
-        configData.setPluginData('fancy-plugin', testData);
-        configData.setPluginData('fancy-plugin', newData);
-
-        expect(configData.plugins['fancy-plugin']).to.deep.equal(newData);
-        expect(configData.plugins['fancy-plugin'].arbitrary).to.be.undefined;
-      });
-
-      test.it('should remove data for plugin', () => {
-        const configData = new ConfigData();
-        const testData = { arbitrary: 'data' };
-        configData.setPluginData('fancy-plugin', testData);
-        configData.removePluginData('fancy-plugin');
-
-        expect(configData.plugins['fancy-plugin']).to.be.undefined;
-      });
-    });
-
     describe('Config', () => {
       const tempConfigDir = tmp.dirSync({ unsafeCleanup: true });
 
@@ -243,7 +212,6 @@ describe('services', () => {
         userConfig.addProfile('  profile  \t', 'sid  \n ', '    stage');
         userConfig.setActiveProfile('\tprofile\t');
         userConfig.ackPrompt('impromptu');
-        userConfig.setPluginData('fancy-plugin', 'plugin-data');
 
         const saveMessage = await config.save(userConfig);
         expect(saveMessage).to.contain(`${tempConfigDir.name}${path.sep}config.json`);

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -206,11 +206,11 @@ describe('services', () => {
     describe('ConfigData.setPluginData', () => {
       test.it('should add data for a new plugin', () => {
         const configData = new ConfigData();
-        expect(configData.plugins['fancy-plugin']).to.be.undefined;
+        expect(configData.getPluginData('fancy-plugin')).to.be.undefined;
         const testData = { arbitrary: 'data' };
         configData.setPluginData('fancy-plugin', testData);
 
-        expect(configData.plugins['fancy-plugin']).to.deep.equal(testData);
+        expect(configData.getPluginData('fancy-plugin')).to.deep.equal(testData);
       });
 
       test.it('should update data for an existing plugin', () => {
@@ -220,8 +220,8 @@ describe('services', () => {
         configData.setPluginData('fancy-plugin', testData);
         configData.setPluginData('fancy-plugin', newData);
 
-        expect(configData.plugins['fancy-plugin']).to.deep.equal(newData);
-        expect(configData.plugins['fancy-plugin'].arbitrary).to.be.undefined;
+        expect(configData.getPluginData('fancy-plugin')).to.deep.equal(newData);
+        expect(configData.getPluginData('fancy-plugin').arbitrary).to.be.undefined;
       });
 
       test.it('should remove data for plugin', () => {
@@ -230,7 +230,7 @@ describe('services', () => {
         configData.setPluginData('fancy-plugin', testData);
         configData.removePluginData('fancy-plugin');
 
-        expect(configData.plugins['fancy-plugin']).to.be.undefined;
+        expect(configData.getPluginData('fancy-plugin')).to.be.undefined;
       });
     });
 

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const fs = require('fs');
 
 const tmp = require('tmp');
 const { expect, test, constants } = require('@twilio/cli-test');

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -206,11 +206,11 @@ describe('services', () => {
     describe('ConfigData.setPluginData', () => {
       test.it('should add data for a new plugin', () => {
         const configData = new ConfigData();
-        expect(configData.getPluginData('fancy-plugin')).to.be.undefined;
+        expect(configData.plugins['fancy-plugin']).to.be.undefined;
         const testData = { arbitrary: 'data' };
         configData.setPluginData('fancy-plugin', testData);
 
-        expect(configData.getPluginData('fancy-plugin')).to.deep.equal(testData);
+        expect(configData.plugins['fancy-plugin']).to.deep.equal(testData);
       });
 
       test.it('should update data for an existing plugin', () => {
@@ -220,8 +220,8 @@ describe('services', () => {
         configData.setPluginData('fancy-plugin', testData);
         configData.setPluginData('fancy-plugin', newData);
 
-        expect(configData.getPluginData('fancy-plugin')).to.deep.equal(newData);
-        expect(configData.getPluginData('fancy-plugin').arbitrary).to.be.undefined;
+        expect(configData.plugins['fancy-plugin']).to.deep.equal(newData);
+        expect(configData.plugins['fancy-plugin'].arbitrary).to.be.undefined;
       });
 
       test.it('should remove data for plugin', () => {
@@ -230,7 +230,7 @@ describe('services', () => {
         configData.setPluginData('fancy-plugin', testData);
         configData.removePluginData('fancy-plugin');
 
-        expect(configData.getPluginData('fancy-plugin')).to.be.undefined;
+        expect(configData.plugins['fancy-plugin']).to.be.undefined;
       });
     });
 

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -203,6 +203,37 @@ describe('services', () => {
       });
     });
 
+    describe('ConfigData.setPluginData', () => {
+      test.it('should add data for a new plugin', () => {
+        const configData = new ConfigData();
+        expect(configData.plugins['fancy-plugin']).to.be.undefined;
+        const testData = { arbitrary: 'data' };
+        configData.setPluginData('fancy-plugin', testData);
+
+        expect(configData.plugins['fancy-plugin']).to.deep.equal(testData);
+      });
+
+      test.it('should update data for an existing plugin', () => {
+        const configData = new ConfigData();
+        const testData = { arbitrary: 'data' };
+        const newData = { new: 'information' };
+        configData.setPluginData('fancy-plugin', testData);
+        configData.setPluginData('fancy-plugin', newData);
+
+        expect(configData.plugins['fancy-plugin']).to.deep.equal(newData);
+        expect(configData.plugins['fancy-plugin'].arbitrary).to.be.undefined;
+      });
+
+      test.it('should remove data for plugin', () => {
+        const configData = new ConfigData();
+        const testData = { arbitrary: 'data' };
+        configData.setPluginData('fancy-plugin', testData);
+        configData.removePluginData('fancy-plugin');
+
+        expect(configData.plugins['fancy-plugin']).to.be.undefined;
+      });
+    });
+
     describe('Config', () => {
       const tempConfigDir = tmp.dirSync({ unsafeCleanup: true });
 
@@ -212,6 +243,7 @@ describe('services', () => {
         userConfig.addProfile('  profile  \t', 'sid  \n ', '    stage');
         userConfig.setActiveProfile('\tprofile\t');
         userConfig.ackPrompt('impromptu');
+        userConfig.setPluginData('fancy-plugin', 'plugin-data');
 
         const saveMessage = await config.save(userConfig);
         expect(saveMessage).to.contain(`${tempConfigDir.name}${path.sep}config.json`);

--- a/test/services/config.test.js
+++ b/test/services/config.test.js
@@ -242,37 +242,24 @@ describe('services', () => {
         tempConfigDir.removeCallback();
       });
 
-      test.it("loads an empty object when the plugin directory doesn't exist", () => {
+      test.it("loads an empty object when the plugin directory doesn't exist", async () => {
         const pluginConfig = new PluginConfig(tempConfigDir.name, 'test-plugin');
-        expect(pluginConfig.getConfig()).to.deep.equal({});
+        expect(await pluginConfig.getConfig()).to.deep.equal({});
       });
 
-      test.it('loads an existing plugin config', () => {
-        fs.mkdirSync(path.join(tempConfigDir.name, 'plugins', 'test-plugin'), { recursive: true });
-        fs.writeFileSync(
-          path.join(tempConfigDir.name, 'plugins', 'test-plugin', 'config.json'),
-          JSON.stringify({ hello: 'world' }),
-        );
+      test.it("saves config to the plugin directory when it doesn't exist", async () => {
         const pluginConfig = new PluginConfig(tempConfigDir.name, 'test-plugin');
-        expect(pluginConfig.getConfig()).to.deep.equal({ hello: 'world' });
+        await pluginConfig.setConfig({ foo: 'bar' });
+        expect(await pluginConfig.getConfig()).to.deep.equal({ foo: 'bar' });
       });
 
-      test.it("saves config to the plugin directory when it doesn't exist", () => {
+      test.it('overwrites config when it already exists', async () => {
         const pluginConfig = new PluginConfig(tempConfigDir.name, 'test-plugin');
-        pluginConfig.setConfig({ foo: 'bar' });
-        expect(pluginConfig.getConfig()).to.deep.equal({ foo: 'bar' });
-      });
+        await pluginConfig.setConfig({ hello: 'world' });
 
-      test.it('overwrites config when it already exists', () => {
-        fs.mkdirSync(path.join(tempConfigDir.name, 'plugins', 'test-plugin'), { recursive: true });
-        fs.writeFileSync(
-          path.join(tempConfigDir.name, 'plugins', 'test-plugin', 'config.json'),
-          JSON.stringify({ hello: 'world' }),
-        );
-
-        const pluginConfig = new PluginConfig(tempConfigDir.name, 'test-plugin');
-        pluginConfig.setConfig({ foo: 'bar' });
-        expect(pluginConfig.getConfig()).to.deep.equal({ foo: 'bar' });
+        const pluginConfig2 = new PluginConfig(tempConfigDir.name, 'test-plugin');
+        await pluginConfig2.setConfig({ foo: 'bar' });
+        expect(await pluginConfig2.getConfig()).to.deep.equal({ foo: 'bar' });
       });
     });
   });


### PR DESCRIPTION
Plugins can read `this.userConfig` but they can't use it to set other data. I am writing a plugin that I think would benefit from a central config store and writing data to `this.userConfig` would be ideal.

I am proposing that we add a `plugins` property to the object and allow for plugins to add arbitrary data under their own namespace. e.g.

```javascript
this.userConfig.setPluginData('my-new-plugin', { this: 'is', really: 'cool' });

this.userConfig.getPluginData('my-new-plugin').really;
// => 'cool';
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli-core/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
