### PR TITLE
fix: need to use the plugin name, not the plugin object

### DIFF
--- a/src/base-commands/base-command.js
+++ b/src/base-commands/base-command.js
@@ -173,8 +173,8 @@ class BaseCommand extends Command {
 
   get pluginConfig() {
     if (!this._pluginConfig) {
-      const pluginName = getCommandPlugin(this);
-      this._pluginConfig = new PluginConfig(this.config.configDir, pluginName);
+      const plugin = getCommandPlugin(this);
+      this._pluginConfig = new PluginConfig(this.config.configDir, plugin.name);
     }
     return this._pluginConfig;
   }


### PR DESCRIPTION
When connecting the plugin config to the base command, I passed through the result of `getCommandPlugin(this)` which is a plugin object and not a string. This lead to `path.join` throwing an error. 🤦‍♂️ 

This fixes that.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli-core/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
