### PR TITLE
chore: standardize User-Agent string: format and include more details

### DIFF
--- a/src/base-commands/twilio-client-command.js
+++ b/src/base-commands/twilio-client-command.js
@@ -26,7 +26,7 @@ class TwilioClientCommand extends BaseCommand {
 
     this.currentProfile = this.userConfig.getProfileById(this.flags.profile);
     let keytarFlag = false;
-    const helper_library = (this.config.userAgent || ' ').split(' ')[0];
+    const helperLibrary = (this.config.userAgent || ' ').split(' ')[0];
 
     const reportUnconfigured = (verb, message = '') => {
       const profileParam = this.flags.profile ? ` --profile "${this.flags.profile}"` : '';
@@ -52,7 +52,7 @@ class TwilioClientCommand extends BaseCommand {
       keytarFlag = true;
     }
 
-    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag, helper_library);
+    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag, helperLibrary);
   }
 
   async catch(error) {

--- a/src/base-commands/twilio-client-command.js
+++ b/src/base-commands/twilio-client-command.js
@@ -26,7 +26,7 @@ class TwilioClientCommand extends BaseCommand {
 
     this.currentProfile = this.userConfig.getProfileById(this.flags.profile);
     let keytarFlag = false;
-    const helperLibrary = (this.config.userAgent || ' ').split(' ')[0];
+    const pluginName = (this.config.userAgent || ' ').split(' ')[0];
 
     const reportUnconfigured = (verb, message = '') => {
       const profileParam = this.flags.profile ? ` --profile "${this.flags.profile}"` : '';
@@ -52,7 +52,7 @@ class TwilioClientCommand extends BaseCommand {
       keytarFlag = true;
     }
 
-    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag, helperLibrary);
+    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag, pluginName);
   }
 
   async catch(error) {

--- a/src/base-commands/twilio-client-command.js
+++ b/src/base-commands/twilio-client-command.js
@@ -26,6 +26,7 @@ class TwilioClientCommand extends BaseCommand {
 
     this.currentProfile = this.userConfig.getProfileById(this.flags.profile);
     let keytarFlag = false;
+    const helper_library = (this.config.userAgent || ' ').split(' ')[0];
 
     const reportUnconfigured = (verb, message = '') => {
       const profileParam = this.flags.profile ? ` --profile "${this.flags.profile}"` : '';
@@ -51,7 +52,7 @@ class TwilioClientCommand extends BaseCommand {
       keytarFlag = true;
     }
 
-    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag);
+    this.httpClient = new CliRequestClient(this.id, this.logger, undefined, keytarFlag, helper_library);
   }
 
   async catch(error) {

--- a/src/services/cli-http-client.js
+++ b/src/services/cli-http-client.js
@@ -17,7 +17,7 @@ class CliRequestClient {
   constructor(commandName, logger, http, keytarFlag = false, extensions = ' ') {
     this.commandName = commandName;
     this.logger = logger;
-    this.helperLibrary = extensions;
+    this.pluginName = extensions;
     this.http = http || require('axios');
     if (process.env.HTTP_PROXY) {
       /*
@@ -65,14 +65,15 @@ class CliRequestClient {
       const b64Auth = Buffer.from(`${opts.username}:${opts.password}`).toString('base64');
       headers.Authorization = `Basic ${b64Auth}`;
     }
+    // User-Agent will have these info : <plugin/version> <core-api-lib>/<core-api-lib-version> (<os-name> <os-arch>) <extensions>
     const componentInfo = [];
-    componentInfo.push(`(${os.platform()} ${os.arch()})`);
-    const userAgentArr = (headers['User-Agent'] || '').split(' ');
-    componentInfo.push(userAgentArr[0]); // extensions
-    componentInfo.push(userAgentArr[3]); // extensions
-    componentInfo.push(this.commandName);
-    componentInfo.push(this.keytarWord);
-    headers['User-Agent'] = `${this.helperLibrary} ${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
+    componentInfo.push(`(${os.platform()} ${os.arch()})`); // (<os-name> <os-arch>)
+    const userAgentArr = (headers['User-Agent'] || ' ').split(' '); // contains twilio-node/version (darwin x64) node/v16.4.2
+    componentInfo.push(userAgentArr[0]); // Api client version
+    componentInfo.push(userAgentArr[3]); // nodejs version
+    componentInfo.push(this.commandName); // cli-command
+    componentInfo.push(this.keytarWord); // keytar flag
+    headers['User-Agent'] = `${this.pluginName} ${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
 
     const options = {
       timeout: opts.timeout || 30000,

--- a/src/services/cli-http-client.js
+++ b/src/services/cli-http-client.js
@@ -65,12 +65,15 @@ class CliRequestClient {
       headers.Authorization = `Basic ${b64Auth}`;
     }
 
-    const componentInfo = (headers['User-Agent'] || '').replace(' (', '|').replace(')', '').split('|');
-    componentInfo.push(`${os.platform()} ${os.release()} ${os.arch()}`);
+    
+    const componentInfo = [];
+    componentInfo.push(`(${os.platform()} ${os.arch()})`);
+    const userAgentArr = (headers['User-Agent'] || '').split(' ');
+    componentInfo.push(userAgentArr[0]); //extensions
+    componentInfo.push(userAgentArr[3]); //extensions
     componentInfo.push(this.commandName);
     componentInfo.push(this.keytarWord);
-    headers['User-Agent'] = `${pkg.name}/${pkg.version} (${componentInfo.filter(Boolean).join(', ')})`;
-
+    headers['User-Agent'] = `${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
     const options = {
       timeout: opts.timeout || 30000,
       maxRedirects: opts.allowRedirects ? 10 : 0,

--- a/src/services/cli-http-client.js
+++ b/src/services/cli-http-client.js
@@ -14,10 +14,10 @@ const NETWORK_ERROR_CODES = new Set(['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNABORT
 const STANDARD_HEADERS = ['user-agent', 'accept-charset', 'connection', 'authorization', 'accept', 'content-type'];
 
 class CliRequestClient {
-  constructor(commandName, logger, http, keytarFlag = false, helper_library ='') {
+  constructor(commandName, logger, http, keytarFlag = false, extensions = ' ') {
     this.commandName = commandName;
     this.logger = logger;
-    this.helper_library = helper_library;
+    this.helperLibrary = extensions;
     this.http = http || require('axios');
     if (process.env.HTTP_PROXY) {
       /*
@@ -40,7 +40,7 @@ class CliRequestClient {
    * @param {string} [opts.password] - The password used for auth
    * @param {object} [opts.headers] - The request headers
    * @param {object} [opts.params] - The request params
-   * @param {object} [opts.data] - The request data 
+   * @param {object} [opts.data] - The request data
    * @param {int} [opts.timeout=30000] - The request timeout in milliseconds
    * @param {boolean} [opts.allowRedirects] - Should the client follow redirects
    * @param {boolean} [opts.forever] - Set to true to use the forever-agent
@@ -65,16 +65,15 @@ class CliRequestClient {
       const b64Auth = Buffer.from(`${opts.username}:${opts.password}`).toString('base64');
       headers.Authorization = `Basic ${b64Auth}`;
     }
-
-    
     const componentInfo = [];
     componentInfo.push(`(${os.platform()} ${os.arch()})`);
     const userAgentArr = (headers['User-Agent'] || '').split(' ');
-    componentInfo.push(userAgentArr[0]); //extensions
-    componentInfo.push(userAgentArr[3]); //extensions
+    componentInfo.push(userAgentArr[0]); // extensions
+    componentInfo.push(userAgentArr[3]); // extensions
     componentInfo.push(this.commandName);
     componentInfo.push(this.keytarWord);
-    headers['User-Agent'] = this.helper_library + ` ${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
+    headers['User-Agent'] = `${this.helperLibrary} ${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
+
     const options = {
       timeout: opts.timeout || 30000,
       maxRedirects: opts.allowRedirects ? 10 : 0,

--- a/src/services/cli-http-client.js
+++ b/src/services/cli-http-client.js
@@ -14,9 +14,10 @@ const NETWORK_ERROR_CODES = new Set(['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNABORT
 const STANDARD_HEADERS = ['user-agent', 'accept-charset', 'connection', 'authorization', 'accept', 'content-type'];
 
 class CliRequestClient {
-  constructor(commandName, logger, http, keytarFlag = false) {
+  constructor(commandName, logger, http, keytarFlag = false, helper_library ='') {
     this.commandName = commandName;
     this.logger = logger;
+    this.helper_library = helper_library;
     this.http = http || require('axios');
     if (process.env.HTTP_PROXY) {
       /*
@@ -39,7 +40,7 @@ class CliRequestClient {
    * @param {string} [opts.password] - The password used for auth
    * @param {object} [opts.headers] - The request headers
    * @param {object} [opts.params] - The request params
-   * @param {object} [opts.data] - The request data
+   * @param {object} [opts.data] - The request data 
    * @param {int} [opts.timeout=30000] - The request timeout in milliseconds
    * @param {boolean} [opts.allowRedirects] - Should the client follow redirects
    * @param {boolean} [opts.forever] - Set to true to use the forever-agent
@@ -73,7 +74,7 @@ class CliRequestClient {
     componentInfo.push(userAgentArr[3]); //extensions
     componentInfo.push(this.commandName);
     componentInfo.push(this.keytarWord);
-    headers['User-Agent'] = `${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
+    headers['User-Agent'] = this.helper_library + ` ${pkg.name}/${pkg.version} ${componentInfo.filter(Boolean).join(' ')}`;
     const options = {
       timeout: opts.timeout || 30000,
       maxRedirects: opts.allowRedirects ? 10 : 0,

--- a/test/services/cli-http-client.test.js
+++ b/test/services/cli-http-client.test.js
@@ -19,9 +19,11 @@ describe('services', () => {
           return { status: 200, data: 'foo', headers: {} };
         },
         true,
+        'blah',
       );
       expect(client.commandName).to.equal('blah');
       expect(client.keytarWord).to.equal('keytar');
+      expect(client.helperLibrary).to.equal('blah');
       const response = await client.request({
         method: 'POST',
         uri: 'https://foo.com/bar',
@@ -38,9 +40,10 @@ describe('services', () => {
 
     test.it('should add the correct http agent for proxy', async () => {
       process.env.HTTP_PROXY = 'http://someproxy.com:8080';
-      const client = new CliRequestClient('blah', logger, { defaults: {} }, false);
+      const client = new CliRequestClient('blah', logger, { defaults: {} }, false, 'blah');
       const httpAgent = client.http.defaults.httpsAgent;
       expect(client.keytarWord).to.equal('');
+      expect(client.helperLibrary).to.equal('blah');
       expect(httpAgent.proxy.host).to.equal('someproxy.com');
       expect(httpAgent.proxy.port).to.equal(8080);
     });


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <chore>[!]: <standardise userAgent string>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

Closes [DII-72](https://issues.corp.twilio.com/browse/DII-72)

This PR is for standardising the userAgent string format to gain better insights about the metrics involved with cli like usage, potential demand, etc.

Suggested Format:

`<core-api-lib>/<core-api-lib-version> (<os-name> <os-arch>) <extensions>`
Where `<extensions>` are being added space separated following:
`<library>/<library-version>`
or
`<tag>`


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli-core/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

**Testing details:** 
[Gist](https://gist.github.com/shrutiburman/655bf08a0fac79e9d25c1572bb73c30e)
Earlier, this is how the UserAgent string looked like:
![Pasted Graphic 1](https://user-images.githubusercontent.com/87537688/128351657-9acff440-5d81-4501-a263-fef7871954e8.png)

UserAgent string after the change:
![Screenshot 2021-08-05 at 3 42 59 PM](https://user-images.githubusercontent.com/87537688/128351826-7ba9b45a-34f6-4c6a-9b1e-4925cca3fa3c.png)

The userAgent string contains keytar flag and the cli version too as per [this](https://docs.google.com/document/d/1qiI_3ziL1OyEqDm348RHneTUj7fiaRHP_zlnzmpav4w/edit#) doc. 
