### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         id: cli_token
         run: |
           output=$(python3 .github/scripts/validate_cli_tokens.py)
-          echo "::set-output name=tokenStatus::$output"
+          echo "tokenStatus=$output" >> $GITHUB_OUTPUT
       - name: Print status
         run: echo "${{ steps.cli_token.outputs.tokenStatus }}"
       - name: Validate the github workflow
@@ -126,8 +126,8 @@ jobs:
           make install
           cp -R ~/oai_definitions/CHANGES.md OAI_CHANGES.md
           source .github/scripts/update-api-spec-with-changelog.sh
-          echo "::set-output name=change-log::$changeLog"
-          echo "::set-output name=version-type::$versionType"
+          echo "change-log=$changeLog" >> $GITHUB_OUTPUT
+          echo "version-type=$versionType" >> $GITHUB_OUTPUT
   release:
     runs-on: ubuntu-latest
     needs: [update-api-specs]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -78,7 +78,7 @@
     [
       "@semantic-release/exec",
       {
-        "successCmd": "echo '::set-output name=TAG_NAME::${nextRelease.version}'"
+        "successCmd": "echo 'TAG_NAME=${nextRelease.version}' >> $GITHUB_OUTPUT"
       }
     ]
   ]


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


