### PR TITLE
fix: don't load CI-only .github/scripts at runtime (fixes #306)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,4 @@ module.exports = {
     outputFormats: require('./services/output-formats'),
   },
   configureEnv: require('./services/env'),
-  releaseScripts: {
-    UpdateRelease: require('../.github/scripts/update-release'),
-    TriggerWorkflow: require('../.github/scripts/trigger-workflow'),
-  },
 };


### PR DESCRIPTION
Fixes #306

`src/index.js` eagerly `require()`'d two CI-only scripts (`update-release`, `trigger-workflow`) and re-exported them as `releaseScripts`. `update-release.js` requires `@octokit/core`, which is ESM-only, so on Node 20+ (the only Node range CLI 6.x supports) every CLI invocation crashed with `ERR_REQUIRE_ESM` before any command ran.

These scripts are release automation invoked directly by file path in `.github/workflows/release.yml`, never through the package export, and no source under `src/` references `releaseScripts`. Removing them from the runtime entry point fixes the crash with no behavior change.

Verified on Node 20.18.0: module loads cleanly, 192 tests pass, lint clean.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-cli-core/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
